### PR TITLE
spec: add muxed_decode vectors for edge ids and invalid case

### DIFF
--- a/spec/vectors.json
+++ b/spec/vectors.json
@@ -11,7 +11,107 @@
       "expected": {
         "mAddress": "MA7QYNF7SZFX4X7X5JFZZ3UQ6BXHDSY2RKVKZKX5FFQJ1ZMZX1AAJZRE6LRE6LRE6LRE6LRE6LRE6LRE6LRE6LRE6LRE6LRE6LR"
       },
-      "tags": ["edge", "interop"]
+      "tags": [
+        "edge",
+        "interop"
+      ]
+    },
+    {
+      "module": "muxed_decode",
+      "description": "decode id=0 boundary case",
+      "input": {
+        "mAddress": "MAYCUYT553C5LHVE2XPW5GMEJT4BXGM7AHMJWLAPZP53KJO7EIQACAAAAAAAAAAAAD672"
+      },
+      "expected": {
+        "base_g": "GAYCUYT553C5LHVE2XPW5GMEJT4BXGM7AHMJWLAPZP53KJO7EIQADRSI",
+        "baseG": "GAYCUYT553C5LHVE2XPW5GMEJT4BXGM7AHMJWLAPZP53KJO7EIQADRSI",
+        "id": "0"
+      },
+      "tags": [
+        "positive",
+        "edge"
+      ]
+    },
+    {
+      "module": "muxed_decode",
+      "description": "decode id=1 small positive case",
+      "input": {
+        "mAddress": "MAYCUYT553C5LHVE2XPW5GMEJT4BXGM7AHMJWLAPZP53KJO7EIQACAAAAAAAAAAAAHOO2"
+      },
+      "expected": {
+        "base_g": "GAYCUYT553C5LHVE2XPW5GMEJT4BXGM7AHMJWLAPZP53KJO7EIQADRSI",
+        "baseG": "GAYCUYT553C5LHVE2XPW5GMEJT4BXGM7AHMJWLAPZP53KJO7EIQADRSI",
+        "id": "1"
+      },
+      "tags": [
+        "positive",
+        "edge"
+      ]
+    },
+    {
+      "module": "muxed_decode",
+      "description": "decode id=2^53 precision boundary",
+      "input": {
+        "mAddress": "MAYCUYT553C5LHVE2XPW5GMEJT4BXGM7AHMJWLAPZP53KJO7EIQACABAAAAAAAAAAAFZG"
+      },
+      "expected": {
+        "base_g": "GAYCUYT553C5LHVE2XPW5GMEJT4BXGM7AHMJWLAPZP53KJO7EIQADRSI",
+        "baseG": "GAYCUYT553C5LHVE2XPW5GMEJT4BXGM7AHMJWLAPZP53KJO7EIQADRSI",
+        "id": "9007199254740992"
+      },
+      "tags": [
+        "positive",
+        "edge",
+        "interop"
+      ]
+    },
+    {
+      "module": "muxed_decode",
+      "description": "decode id=2^53+1 interop canary",
+      "input": {
+        "mAddress": "MAYCUYT553C5LHVE2XPW5GMEJT4BXGM7AHMJWLAPZP53KJO7EIQACABAAAAAAAAAAEVIG"
+      },
+      "expected": {
+        "base_g": "GAYCUYT553C5LHVE2XPW5GMEJT4BXGM7AHMJWLAPZP53KJO7EIQADRSI",
+        "baseG": "GAYCUYT553C5LHVE2XPW5GMEJT4BXGM7AHMJWLAPZP53KJO7EIQADRSI",
+        "id": "9007199254740993"
+      },
+      "tags": [
+        "positive",
+        "edge",
+        "interop"
+      ]
+    },
+    {
+      "module": "muxed_decode",
+      "description": "decode id=2^64-1 max uint64",
+      "input": {
+        "mAddress": "MAYCUYT553C5LHVE2XPW5GMEJT4BXGM7AHMJWLAPZP53KJO7EIQAD7777777777774OFW"
+      },
+      "expected": {
+        "base_g": "GAYCUYT553C5LHVE2XPW5GMEJT4BXGM7AHMJWLAPZP53KJO7EIQADRSI",
+        "baseG": "GAYCUYT553C5LHVE2XPW5GMEJT4BXGM7AHMJWLAPZP53KJO7EIQADRSI",
+        "id": "18446744073709551615"
+      },
+      "tags": [
+        "positive",
+        "edge",
+        "interop"
+      ]
+    },
+    {
+      "module": "muxed_decode",
+      "description": "invalid M-address should return decode error",
+      "input": {
+        "mAddress": "MZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ"
+      },
+      "expected": {
+        "expected_error": "invalid encoded string"
+      },
+      "tags": [
+        "negative",
+        "edge"
+      ]
     },
     {
       "module": "detect",
@@ -34,7 +134,10 @@
           }
         ]
       },
-      "tags": ["negative", "edge"]
+      "tags": [
+        "negative",
+        "edge"
+      ]
     },
     {
       "module": "extract_routing",
@@ -49,7 +152,10 @@
         "routingSource": "muxed",
         "warnings": []
       },
-      "tags": ["positive", "interop"]
+      "tags": [
+        "positive",
+        "interop"
+      ]
     },
     {
       "module": "extract_routing",
@@ -67,11 +173,15 @@
             "code": "INVALID_DESTINATION",
             "severity": "error",
             "message": "C address is not a valid destination",
-            "context": { "destinationKind": "C" }
+            "context": {
+              "destinationKind": "C"
+            }
           }
         ]
       },
-      "tags": ["negative"]
+      "tags": [
+        "negative"
+      ]
     },
     {
       "module": "extract_routing",
@@ -87,7 +197,9 @@
         "routingSource": "memo",
         "warnings": []
       },
-      "tags": ["positive"]
+      "tags": [
+        "positive"
+      ]
     },
     {
       "module": "extract_routing",
@@ -103,7 +215,9 @@
         "routingSource": "memo",
         "warnings": []
       },
-      "tags": ["positive"]
+      "tags": [
+        "positive"
+      ]
     },
     {
       "module": "extract_routing",
@@ -122,11 +236,17 @@
             "code": "NON_CANONICAL_ROUTING_ID",
             "severity": "warn",
             "message": "Memo routing ID had leading zeros. Normalized to canonical decimal.",
-            "normalization": { "original": "007", "normalized": "7" }
+            "normalization": {
+              "original": "007",
+              "normalized": "7"
+            }
           }
         ]
       },
-      "tags": ["negative", "edge"]
+      "tags": [
+        "negative",
+        "edge"
+      ]
     }
   ]
 }


### PR DESCRIPTION
This pull request expands the test coverage in `spec/vectors.json` by adding new test cases for muxed address decoding, especially covering edge cases and boundary values, and improves the formatting for readability. The most significant changes are grouped below:

### New muxed address decode test cases

* Added test cases for decoding muxed addresses with boundary and edge values, including id=0, id=1, id=2^53, id=2^53+1, and id=2^64-1, to verify correct handling of precision and maximum values.
* Added a negative test case to ensure decoding fails with an invalid muxed address, verifying error handling.

### Improved formatting for test vectors

* Reformatted all `tags` arrays to multi-line for consistency and readability across the file. [[1]](diffhunk://#diff-1feef7b0a67b1940be1209a9a755315feabc0932c77e015cc2496eb570418dceL14-R114) [[2]](diffhunk://#diff-1feef7b0a67b1940be1209a9a755315feabc0932c77e015cc2496eb570418dceL37-R140) [[3]](diffhunk://#diff-1feef7b0a67b1940be1209a9a755315feabc0932c77e015cc2496eb570418dceL52-R158) [[4]](diffhunk://#diff-1feef7b0a67b1940be1209a9a755315feabc0932c77e015cc2496eb570418dceL70-R184) [[5]](diffhunk://#diff-1feef7b0a67b1940be1209a9a755315feabc0932c77e015cc2496eb570418dceL90-R202) [[6]](diffhunk://#diff-1feef7b0a67b1940be1209a9a755315feabc0932c77e015cc2496eb570418dceL106-R220) [[7]](diffhunk://#diff-1feef7b0a67b1940be1209a9a755315feabc0932c77e015cc2496eb570418dceL125-R249)
* Updated object formatting in error contexts and normalization fields to use multi-line style, improving clarity. [[1]](diffhunk://#diff-1feef7b0a67b1940be1209a9a755315feabc0932c77e015cc2496eb570418dceL70-R184) [[2]](diffhunk://#diff-1feef7b0a67b1940be1209a9a755315feabc0932c77e015cc2496eb570418dceL125-R249)
Closes #36 