### PR TITLE
Implement strkey decoding for G, M, and C prefixes from SEP-23 spec

### DIFF
--- a/packages/core-go/address/detect.go
+++ b/packages/core-go/address/detect.go
@@ -1,12 +1,19 @@
 package address
 
-import (
-	"github.com/stellar/go/strkey"
-)
-
 func Detect(address string) string {
-	if strkey.IsValidEd25519PublicKey(address) { return "G" }
-	if strkey.IsValidMed25519PublicKey(address) { return "M" }
-	if strkey.IsValidContract(address) { return "C" }
-	return "invalid"
+	versionByte, _, err := DecodeStrKey(address)
+	if err != nil {
+		return "invalid"
+	}
+
+	switch versionByte {
+	case VersionByteG:
+		return "G"
+	case VersionByteM:
+		return "M"
+	case VersionByteC:
+		return "C"
+	default:
+		return "invalid"
+	}
 }

--- a/packages/core-go/address/errors.go
+++ b/packages/core-go/address/errors.go
@@ -1,5 +1,7 @@
 package address
 
+import "fmt"
+
 type ErrorCode string
 
 const (
@@ -12,3 +14,30 @@ const (
 	ErrFederationAddressNotSupported ErrorCode = "FEDERATION_ADDRESS_NOT_SUPPORTED"
 	ErrUnknownPrefix                 ErrorCode = "UNKNOWN_PREFIX"
 )
+
+// Error variables
+var (
+	ErrInvalidChecksumError    = fmt.Errorf(string(ErrInvalidChecksum))
+	ErrInvalidBase32Error      = fmt.Errorf(string(ErrInvalidBase32))
+	ErrInvalidLengthError      = fmt.Errorf(string(ErrInvalidLength))
+	ErrUnknownVersionByteError = fmt.Errorf("unknown version byte")
+)
+
+// AddressError represents an address-related error
+type AddressError struct {
+	Code    ErrorCode
+	Input   string
+	Message string
+}
+
+func (e *AddressError) Error() string {
+	return e.Message
+}
+
+// ParseResult represents the result of parsing an address
+type ParseResult struct {
+	Kind     string
+	Address  string
+	Warnings []Warning
+	Err      *AddressError
+}

--- a/packages/core-go/address/strkey.go
+++ b/packages/core-go/address/strkey.go
@@ -1,0 +1,137 @@
+package address
+
+import (
+	"encoding/base32"
+	"strings"
+)
+
+// Version bytes for different strkey types
+const (
+	VersionByteG = 6 << 3  // G addresses (ed25519 public key)
+	VersionByteM = 12 << 3 // M addresses (muxed account)
+	VersionByteC = 2 << 3  // C addresses (contract)
+)
+
+// CRC-16 XMODEM table for checksum calculation
+var crc16Table = [256]uint16{
+	0x0000, 0x1021, 0x2042, 0x3063, 0x4084, 0x50a5, 0x60c6, 0x70e7,
+	0x8108, 0x9129, 0xa14a, 0xb16b, 0xc18c, 0xd1ad, 0xe1ce, 0xf1ef,
+	0x1231, 0x0210, 0x3273, 0x2252, 0x52b5, 0x4294, 0x72f7, 0x62d6,
+	0x9339, 0x8318, 0xb37b, 0xa35a, 0xd3bd, 0xc39c, 0xf3ff, 0xe3de,
+	0x2462, 0x3443, 0x0420, 0x1401, 0x64e6, 0x74c7, 0x44a4, 0x5485,
+	0xa56a, 0xb54b, 0x8528, 0x9509, 0xe5ee, 0xf5cf, 0xc5ac, 0xd58d,
+	0x3653, 0x2672, 0x1611, 0x0630, 0x76d7, 0x66f6, 0x5695, 0x46b4,
+	0xb75b, 0xa77a, 0x9719, 0x8738, 0xf7df, 0xe7fe, 0xd79d, 0xc7bc,
+	0x48c4, 0x58e5, 0x6886, 0x78a7, 0x0840, 0x1861, 0x2802, 0x3823,
+	0xc9cc, 0xd9ed, 0xe98e, 0xf9af, 0x8948, 0x9969, 0xa90a, 0xb92b,
+	0x5af5, 0x4ad4, 0x7ab7, 0x6a96, 0x1a71, 0x0a50, 0x3a33, 0x2a12,
+	0xdbfd, 0xcbdc, 0xfbbf, 0xeb9e, 0x9b79, 0x8b58, 0xbb3b, 0xab1a,
+	0x6ca6, 0x7c87, 0x4ce4, 0x5cc5, 0x2c22, 0x3c03, 0x0c60, 0x1c41,
+	0xedae, 0xfd8f, 0xcdec, 0xddcd, 0xad2a, 0xbd0b, 0x8d68, 0x9d49,
+	0x7e97, 0x6eb6, 0x5ed5, 0x4ef4, 0x3e13, 0x2e32, 0x1e51, 0x0e70,
+	0xff9f, 0xefbe, 0xdfdd, 0xcffc, 0xbf1b, 0xaf3a, 0x9f59, 0x8f78,
+	0x9188, 0x81a9, 0xb1ca, 0xa1eb, 0xd10c, 0xc12d, 0xf14e, 0xe16f,
+	0x1080, 0x00a1, 0x30c2, 0x20e3, 0x5004, 0x4025, 0x7046, 0x6067,
+	0x83b9, 0x9398, 0xa3fb, 0xb3da, 0xc33d, 0xd31c, 0xe37f, 0xf35e,
+	0x02b1, 0x1290, 0x22f3, 0x32d2, 0x4235, 0x5214, 0x6277, 0x7256,
+	0xb5ea, 0xa5cb, 0x95a8, 0x8589, 0xf56e, 0xe54f, 0xd52c, 0xc50d,
+	0x34e2, 0x24c3, 0x14a0, 0x0481, 0x7466, 0x6447, 0x5424, 0x4405,
+	0xa7db, 0xb7fa, 0x8799, 0x97b8, 0xe75f, 0xf77e, 0xc71d, 0xd73c,
+	0x26d3, 0x36f2, 0x0691, 0x16b0, 0x6657, 0x7676, 0x4615, 0x5634,
+	0xd94c, 0xc96d, 0xf90e, 0xe92f, 0x99c8, 0x89e9, 0xb98a, 0xa9ab,
+	0x5844, 0x4865, 0x7806, 0x6827, 0x18c0, 0x08e1, 0x3882, 0x28a3,
+	0xcb7d, 0xdb5c, 0xeb3f, 0xfb1e, 0x8bf9, 0x9bd8, 0xabbb, 0xbb9a,
+	0x4a75, 0x5a54, 0x6a37, 0x7a16, 0x0af1, 0x1ad0, 0x2ab3, 0x3a92,
+	0xfd2e, 0xed0f, 0xdd6c, 0xcd4d, 0xbdaa, 0xad8b, 0x9de8, 0x8dc9,
+	0x7c26, 0x6c07, 0x5c64, 0x4c45, 0x3ca2, 0x2c83, 0x1ce0, 0x0cc1,
+	0xef1f, 0xff3e, 0xcf5d, 0xdf7c, 0xaf9b, 0xbfba, 0x8fd9, 0x9ff8,
+	0x6e17, 0x7e36, 0x4e55, 0x5e74, 0x2e93, 0x3eb2, 0x0ed1, 0x1ef0,
+}
+
+// calculateCRC16XModem calculates CRC-16 XMODEM checksum
+func calculateCRC16XModem(data []byte) uint16 {
+	crc := uint16(0)
+	for _, b := range data {
+		lookupIndex := (crc >> 8) ^ uint16(b)
+		crc = (crc << 8) ^ crc16Table[lookupIndex]
+		crc &= 0xffff
+	}
+	return crc
+}
+
+// decodeStrKey decodes a strkey address and returns version byte, payload, and error
+func DecodeStrKey(address string) (versionByte byte, payload []byte, err error) {
+	if address == "" {
+		return 0, nil, ErrInvalidLengthError
+	}
+
+	// Convert to uppercase for base32 decoding
+	address = strings.ToUpper(address)
+
+	// Check basic length constraints
+	if len(address) < 3 {
+		return 0, nil, ErrInvalidLengthError
+	}
+
+	// Base32 decode without padding
+	decoder := base32.StdEncoding.WithPadding(base32.NoPadding)
+	decoded, err := decoder.DecodeString(address)
+	if err != nil {
+		return 0, nil, ErrInvalidBase32Error
+	}
+
+	// Verify round-trip encoding to catch invalid inputs
+	// This is required by SEP-23 to reject strings that don't re-encode to the same string
+	reencoded := decoder.EncodeToString(decoded)
+	if reencoded != address {
+		return 0, nil, ErrInvalidBase32Error
+	}
+
+	// Minimum length: version byte (1) + payload (at least 1) + checksum (2)
+	if len(decoded) < 4 {
+		return 0, nil, ErrInvalidLengthError
+	}
+
+	// Extract version byte, payload, and checksum
+	versionByte = decoded[0]
+	payload = decoded[:len(decoded)-2]
+	checksum := decoded[len(decoded)-2:]
+
+	// Validate version byte
+	switch versionByte {
+	case VersionByteG, VersionByteM, VersionByteC:
+		// Valid version bytes
+	default:
+		return 0, nil, ErrUnknownVersionByteError
+	}
+
+	// Calculate and verify checksum
+	expectedCRC := calculateCRC16XModem(payload)
+	expectedChecksum := []byte{byte(expectedCRC & 0xff), byte((expectedCRC >> 8) & 0xff)}
+
+	if checksum[0] != expectedChecksum[0] || checksum[1] != expectedChecksum[1] {
+		return 0, nil, ErrInvalidChecksumError
+	}
+
+	// Return payload without version byte
+	return versionByte, payload[1:], nil
+}
+
+// encodeStrKey encodes a payload with a version byte and checksum
+func EncodeStrKey(versionByte byte, payload []byte) (string, error) {
+	// Create versioned payload
+	versionedPayload := make([]byte, 1+len(payload))
+	versionedPayload[0] = versionByte
+	copy(versionedPayload[1:], payload)
+
+	// Calculate checksum
+	crc := calculateCRC16XModem(versionedPayload)
+	checksum := []byte{byte(crc & 0xff), byte((crc >> 8) & 0xff)}
+
+	// Append checksum
+	fullPayload := append(versionedPayload, checksum...)
+
+	// Base32 encode without padding
+	encoder := base32.StdEncoding.WithPadding(base32.NoPadding)
+	return encoder.EncodeToString(fullPayload), nil
+}

--- a/packages/core-go/address/strkey_test.go
+++ b/packages/core-go/address/strkey_test.go
@@ -1,0 +1,106 @@
+package address
+
+import (
+	"testing"
+)
+
+func TestDecodeStrKey(t *testing.T) {
+	tests := []struct {
+		name        string
+		address     string
+		expectedVB  byte
+		expectError bool
+	}{
+		{
+			name:       "Valid G address",
+			address:    "GAYCUYT553C5LHVE2XPW5GMEJT4BXGM7AHMJWLAPZP53KJO7EIQADRSI",
+			expectedVB: VersionByteG,
+		},
+		{
+			name:       "Valid M address",
+			address:    "MAYCUYT553C5LHVE2XPW5GMEJT4BXGM7AHMJWLAPZP53KJO7EIQACAAAAAAAAAAAAD672",
+			expectedVB: VersionByteM,
+		},
+		{
+			name:        "Invalid checksum",
+			address:     "GAYCUYT553C5LHVE2XPW5GMEJT4BXGM7AHMJWLAPZP53KJO7EIQADRSJ", // Last char changed
+			expectError: true,
+		},
+		{
+			name:        "Invalid base32",
+			address:     "GZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ",
+			expectError: true,
+		},
+		{
+			name:        "Unknown version byte",
+			address:     "SAYCUYT553C5LHVE2XPW5GMEJT4BXGM7AHMJWLAPZP53KJO7EIQADRSI", // S is seed
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vb, payload, err := DecodeStrKey(tt.address)
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("expected error but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+
+			if vb != tt.expectedVB {
+				t.Errorf("expected version byte %d, got %d", tt.expectedVB, vb)
+			}
+
+			// Check payload length
+			if tt.address[0] == 'G' || tt.address[0] == 'C' {
+				if len(payload) != 32 {
+					t.Errorf("expected payload length 32, got %d", len(payload))
+				}
+			} else if tt.address[0] == 'M' {
+				if len(payload) != 40 {
+					t.Errorf("expected payload length 40, got %d", len(payload))
+				}
+			}
+		})
+	}
+}
+
+func TestDetect(t *testing.T) {
+	tests := []struct {
+		name     string
+		address  string
+		expected string
+	}{
+		{
+			name:     "Valid G address",
+			address:  "GAYCUYT553C5LHVE2XPW5GMEJT4BXGM7AHMJWLAPZP53KJO7EIQADRSI",
+			expected: "G",
+		},
+		{
+			name:     "Valid M address",
+			address:  "MAYCUYT553C5LHVE2XPW5GMEJT4BXGM7AHMJWLAPZP53KJO7EIQACAAAAAAAAAAAAD672",
+			expected: "M",
+		},
+		{
+			name:     "Invalid address",
+			address:  "INVALID",
+			expected: "invalid",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := Detect(tt.address)
+			if result != tt.expected {
+				t.Errorf("expected %s, got %s", tt.expected, result)
+			}
+		})
+	}
+}

--- a/packages/core-go/muxed/decode.go
+++ b/packages/core-go/muxed/decode.go
@@ -1,21 +1,39 @@
 package muxed
 
 import (
+	"encoding/binary"
+	"errors"
 	"strconv"
 
-	"github.com/stellar/go/strkey"
+	"github.com/stellar-address-kit/core-go/address"
 )
 
 func DecodeMuxed(mAddress string) (string, string, error) {
-	pubkey, id, err := strkey.DecodeMuxedAccount(mAddress)
+	versionByte, payload, err := address.DecodeStrKey(mAddress)
 	if err != nil {
 		return "", "", err
 	}
 
-	baseG, err := strkey.Encode(strkey.VersionByteAccountID, pubkey)
+	if versionByte != address.VersionByteM {
+		return "", "", errors.New("unknown version byte")
+	}
+
+	// For muxed accounts, payload is: 32-byte pubkey + 8-byte memo ID
+	if len(payload) != 40 {
+		return "", "", errors.New("invalid length")
+	}
+
+	// Extract the 32-byte public key
+	pubkey := payload[:32]
+
+	// Extract the 8-byte memo ID (big endian)
+	memoID := binary.BigEndian.Uint64(payload[32:40])
+
+	// Encode the public key as a G address
+	baseG, err := address.EncodeStrKey(address.VersionByteG, pubkey)
 	if err != nil {
 		return "", "", err
 	}
 
-	return baseG, strconv.FormatUint(id, 10), nil
+	return baseG, strconv.FormatUint(memoID, 10), nil
 }

--- a/packages/core-go/muxed/encode.go
+++ b/packages/core-go/muxed/encode.go
@@ -1,18 +1,33 @@
 package muxed
 
 import (
+	"encoding/binary"
 	"math/big"
-	"github.com/stellar/go/strkey"
+	"strconv"
+
+	"github.com/stellar-address-kit/core-go/address"
 )
 
 func EncodeMuxed(baseG string, id string) (string, error) {
-	pubkey, err := strkey.Decode(strkey.VersionByteAccountID, baseG)
+	versionByte, pubkey, err := address.DecodeStrKey(baseG)
 	if err != nil {
 		return "", err
 	}
-	
+
+	if versionByte != address.VersionByteG {
+		return "", strconv.ErrSyntax
+	}
+
+	// Parse the ID as uint64
 	idInt := new(big.Int)
 	idInt.SetString(id, 10)
-	
-	return strkey.EncodeMuxedAccount(pubkey, idInt.Uint64())
+	memoID := idInt.Uint64()
+
+	// Create muxed payload: 32-byte pubkey + 8-byte memo ID (big endian)
+	payload := make([]byte, 40)
+	copy(payload, pubkey)
+	binary.BigEndian.PutUint64(payload[32:], memoID)
+
+	// Encode as M address
+	return address.EncodeStrKey(address.VersionByteM, payload)
 }

--- a/packages/core-go/muxed/muxed_test.go
+++ b/packages/core-go/muxed/muxed_test.go
@@ -1,0 +1,77 @@
+package muxed
+
+import (
+	"testing"
+)
+
+func TestDecodeMuxed(t *testing.T) {
+	tests := []struct {
+		name          string
+		mAddress      string
+		expectedBaseG string
+		expectedID    string
+		expectError   bool
+	}{
+		{
+			name:          "decode id=0 boundary case",
+			mAddress:      "MAYCUYT553C5LHVE2XPW5GMEJT4BXGM7AHMJWLAPZP53KJO7EIQACAAAAAAAAAAAAD672",
+			expectedBaseG: "GAYCUYT553C5LHVE2XPW5GMEJT4BXGM7AHMJWLAPZP53KJO7EIQADRSI",
+			expectedID:    "0",
+		},
+		{
+			name:          "decode id=1 small positive case",
+			mAddress:      "MAYCUYT553C5LHVE2XPW5GMEJT4BXGM7AHMJWLAPZP53KJO7EIQACAAAAAAAAAAAAHOO2",
+			expectedBaseG: "GAYCUYT553C5LHVE2XPW5GMEJT4BXGM7AHMJWLAPZP53KJO7EIQADRSI",
+			expectedID:    "1",
+		},
+		{
+			name:          "decode id=2^53 precision boundary",
+			mAddress:      "MAYCUYT553C5LHVE2XPW5GMEJT4BXGM7AHMJWLAPZP53KJO7EIQACABAAAAAAAAAAAFZG",
+			expectedBaseG: "GAYCUYT553C5LHVE2XPW5GMEJT4BXGM7AHMJWLAPZP53KJO7EIQADRSI",
+			expectedID:    "9007199254740992",
+		},
+		{
+			name:          "decode id=2^53+1 interop canary",
+			mAddress:      "MAYCUYT553C5LHVE2XPW5GMEJT4BXGM7AHMJWLAPZP53KJO7EIQACABAAAAAAAAAAEVIG",
+			expectedBaseG: "GAYCUYT553C5LHVE2XPW5GMEJT4BXGM7AHMJWLAPZP53KJO7EIQADRSI",
+			expectedID:    "9007199254740993",
+		},
+		{
+			name:          "decode id=2^64-1 max uint64",
+			mAddress:      "MAYCUYT553C5LHVE2XPW5GMEJT4BXGM7AHMJWLAPZP53KJO7EIQAD7777777777774OFW",
+			expectedBaseG: "GAYCUYT553C5LHVE2XPW5GMEJT4BXGM7AHMJWLAPZP53KJO7EIQADRSI",
+			expectedID:    "18446744073709551615",
+		},
+		{
+			name:        "invalid M-address should return decode error",
+			mAddress:    "MZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			baseG, id, err := DecodeMuxed(tt.mAddress)
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("expected error but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+
+			if baseG != tt.expectedBaseG {
+				t.Errorf("expected baseG %s, got %s", tt.expectedBaseG, baseG)
+			}
+
+			if id != tt.expectedID {
+				t.Errorf("expected id %s, got %s", tt.expectedID, id)
+			}
+		})
+	}
+}

--- a/packages/core-go/routing/extract.go
+++ b/packages/core-go/routing/extract.go
@@ -41,7 +41,7 @@ func ExtractRouting(input RoutingInput) RoutingResult {
 		baseG, id, _ := muxed.DecodeMuxed(parsed.Address)
 		warnings := append([]address.Warning{}, parsed.Warnings...)
 
-		if input.MemoType == "id" || (input.MemoType == "text" && digitsOnlyRegex.MatchString(input.MemoValue)) {
+		if input.MemoType == "id" || (input.MemoType == "text" && input.MemoValue != "" && digitsOnlyRegex.MatchString(input.MemoValue)) {
 			warnings = append(warnings, address.Warning{
 				Code:     address.WarnMemoPresentWithMuxed,
 				Severity: "warn",

--- a/packages/core-go/routing/extract_test.go
+++ b/packages/core-go/routing/extract_test.go
@@ -1,0 +1,100 @@
+package routing
+
+import (
+	"testing"
+
+	"github.com/stellar-address-kit/core-go/address"
+)
+
+func TestExtractRouting_SpecVectors(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    RoutingInput
+		expected RoutingResult
+	}{
+		{
+			name: "M-address routing (no memo)",
+			input: RoutingInput{
+				Destination: "MAYCUYT553C5LHVE2XPW5GMEJT4BXGM7AHMJWLAPZP53KJO7EIQACABAAAAAAAAAAEVIG",
+				MemoType:    "none",
+			},
+			expected: RoutingResult{
+				DestinationBaseAccount: "GAYCUYT553C5LHVE2XPW5GMEJT4BXGM7AHMJWLAPZP53KJO7EIQADRSI",
+				RoutingID:              "9007199254740993",
+				RoutingSource:          "muxed",
+				Warnings:               []address.Warning{},
+			},
+		},
+		{
+			name: "G-address + MEMO_ID routing",
+			input: RoutingInput{
+				Destination: "GAYCUYT553C5LHVE2XPW5GMEJT4BXGM7AHMJWLAPZP53KJO7EIQADRSI",
+				MemoType:    "id",
+				MemoValue:   "100",
+			},
+			expected: RoutingResult{
+				DestinationBaseAccount: "GAYCUYT553C5LHVE2XPW5GMEJT4BXGM7AHMJWLAPZP53KJO7EIQADRSI",
+				RoutingID:              "100",
+				RoutingSource:          "memo",
+				Warnings:               []address.Warning{},
+			},
+		},
+		{
+			name: "G-address + MEMO_TEXT numeric routing",
+			input: RoutingInput{
+				Destination: "GAYCUYT553C5LHVE2XPW5GMEJT4BXGM7AHMJWLAPZP53KJO7EIQADRSI",
+				MemoType:    "text",
+				MemoValue:   "200",
+			},
+			expected: RoutingResult{
+				DestinationBaseAccount: "GAYCUYT553C5LHVE2XPW5GMEJT4BXGM7AHMJWLAPZP53KJO7EIQADRSI",
+				RoutingID:              "200",
+				RoutingSource:          "memo",
+				Warnings:               []address.Warning{},
+			},
+		},
+		{
+			name: "Memo ID leading zeros normalization",
+			input: RoutingInput{
+				Destination: "GAYCUYT553C5LHVE2XPW5GMEJT4BXGM7AHMJWLAPZP53KJO7EIQADRSI",
+				MemoType:    "id",
+				MemoValue:   "007",
+			},
+			expected: RoutingResult{
+				DestinationBaseAccount: "GAYCUYT553C5LHVE2XPW5GMEJT4BXGM7AHMJWLAPZP53KJO7EIQADRSI",
+				RoutingID:              "7",
+				RoutingSource:          "memo",
+				Warnings: []address.Warning{
+					{
+						Code:     address.WarnNonCanonicalRoutingID,
+						Severity: "warn",
+						Message:  "Memo routing ID had leading zeros. Normalized to canonical decimal.",
+						Normalization: &address.Normalization{
+							Original:   "007",
+							Normalized: "7",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ExtractRouting(tt.input)
+
+			if result.DestinationBaseAccount != tt.expected.DestinationBaseAccount {
+				t.Errorf("DestinationBaseAccount = %v, want %v", result.DestinationBaseAccount, tt.expected.DestinationBaseAccount)
+			}
+			if result.RoutingID != tt.expected.RoutingID {
+				t.Errorf("RoutingID = %v, want %v", result.RoutingID, tt.expected.RoutingID)
+			}
+			if result.RoutingSource != tt.expected.RoutingSource {
+				t.Errorf("RoutingSource = %v, want %v", result.RoutingSource, tt.expected.RoutingSource)
+			}
+			if len(result.Warnings) != len(tt.expected.Warnings) {
+				t.Errorf("Warnings count = %v, want %v", len(result.Warnings), len(tt.expected.Warnings))
+			}
+		})
+	}
+}

--- a/packages/core-go/routing/input.go
+++ b/packages/core-go/routing/input.go
@@ -3,6 +3,6 @@ package routing
 type RoutingInput struct {
 	Destination   string
 	MemoType      string
-	MemoValue     *string
-	SourceAccount *string
+	MemoValue     string
+	SourceAccount string
 }

--- a/packages/core-go/routing/memo.go
+++ b/packages/core-go/routing/memo.go
@@ -9,7 +9,10 @@ import (
 )
 
 var digitsOnly = regexp.MustCompile(`^\d+$`)
-var uint64Max = new(big.Int).SetString("18446744073709551615", 10)
+var uint64Max = func() *big.Int {
+	val, _ := new(big.Int).SetString("18446744073709551615", 10)
+	return val
+}()
 
 type NormalizeResult struct {
 	Normalized string

--- a/packages/core-go/routing/result.go
+++ b/packages/core-go/routing/result.go
@@ -1,8 +1,6 @@
 package routing
 
 import (
-	"strconv"
-	
 	"github.com/stellar-address-kit/core-go/address"
 )
 
@@ -16,38 +14,9 @@ const (
 	MemoTypeReturn MemoType = "return"
 )
 
-type RoutingID struct {
-	raw string
-}
-
-func (r *RoutingID) String() string {
-	if r == nil {
-		return ""
-	}
-	return r.raw
-}
-
-func (r *RoutingID) Uint64() (uint64, error) {
-	if r == nil {
-		return 0, strconv.ErrSyntax
-	}
-	return strconv.ParseUint(r.raw, 10, 64)
-}
-
-func NewRoutingID(s string) *RoutingID {
-	return &RoutingID{raw: s}
-}
-
-type RoutingInput struct {
-	Destination   string
-	MemoType      string
-	MemoValue     *string
-	SourceAccount *string
-}
-
 type RoutingResult struct {
 	DestinationBaseAccount string
-	RoutingID              *RoutingID
+	RoutingID              string
 	RoutingSource          string // "muxed" | "memo" | "none"
 	Warnings               []address.Warning
 	DestinationError       *DestinationError


### PR DESCRIPTION
Closes #29 Implement strkey decoding for G, M, and C prefixes from SEP-23 spec

- Added direct SEP-23 strkey implementation in address/strkey.go
- Implemented base32 decoding, version byte handling, and CRC-16 validation
- Supported G (6<<3), M (12<<3), and C (2<<3) address types
- Fix routing compatibility issues with TypeScript specification
- Change RoutingInput.MemoValue from *string to string
- Change RoutingResult.RoutingID from *RoutingID to string
- Remove RoutingID struct complexity, use plain strings
- Added comprehensive tests for strkey decoding and routing extraction
- All muxed decode vectors and spec vectors pass