### PR TITLE
Add core Address type definition

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "kiroAgent.configureMCP": "Disabled"
+}

--- a/packages/core-ts/src/address/types.ts
+++ b/packages/core-ts/src/address/types.ts
@@ -1,3 +1,21 @@
+export type AddressKind = "G" | "M" | "C";
+
+export type Address =
+  | {
+      kind: "G";
+      address: string;
+    }
+  | {
+      kind: "M";
+      address: string;
+      baseG: string;
+      muxedId: bigint;
+    }
+  | {
+      kind: "C";
+      address: string;
+    };
+
 export type ErrorCode =
   | "INVALID_CHECKSUM"
   | "INVALID_LENGTH"


### PR DESCRIPTION
Closes #35 
### Changes
- Added `AddressKind` string literal union type with values `"G"`, `"M"`, and `"C"`
- Added `Address` discriminated union type with variants for each address kind
- Muxed addresses (`kind: "M"`) include `baseG` and `muxedId` fields
- All address variants carry the raw `address` string and `kind` discriminator

### Type Structure
```typescript
type AddressKind = "G" | "M" | "C";

type Address =
  | { kind: "G"; address: string }
  | { kind: "M"; address: string; baseG: string; muxedId: bigint }
  | { kind: "C"; address: string };