### PR TITLE
feat(routing): add RoutingWarning immutable type with standard warnin…

### DIFF
--- a/packages/core-dart/lib/src/routing/result.dart
+++ b/packages/core-dart/lib/src/routing/result.dart
@@ -39,3 +39,23 @@ class DestinationError {
 
   DestinationError({required this.code, required this.message});
 }
+
+class RoutingWarning {
+  final String code;
+
+  const RoutingWarning(this.code);
+
+  static const memoIgnored = RoutingWarning('memo-ignored');
+  static const contractSender = RoutingWarning('contract-sender');
+
+  @override
+  String toString() => code;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is RoutingWarning && runtimeType == other.runtimeType && code == other.code;
+
+  @override
+  int get hashCode => code.hashCode;
+}


### PR DESCRIPTION
## Summary
Adds an immutable `RoutingWarning` type with standard routing warning codes.

## Changes
- Introduced `RoutingWarning` with `code` field
- Added constants:
  - `memo-ignored`
  - `contract-sender`

## Scope
No changes to existing logic. Backward compatible.

Closes #68