### PR TITLE
Replace fmt.Errorf calls with named AddressError types in muxed package

### DIFF
--- a/packages/core-go/muxed/decode.go
+++ b/packages/core-go/muxed/decode.go
@@ -2,7 +2,6 @@ package muxed
 
 import (
 	"encoding/binary"
-	"errors"
 	"strconv"
 
 	"github.com/stellar-address-kit/core-go/address"
@@ -15,12 +14,12 @@ func DecodeMuxed(mAddress string) (string, string, error) {
 	}
 
 	if versionByte != address.VersionByteM {
-		return "", "", errors.New("unknown version byte")
+		return "", "", ErrUnknownVersionByteError
 	}
 
 	// For muxed accounts, payload is: 32-byte pubkey + 8-byte memo ID
 	if len(payload) != 40 {
-		return "", "", errors.New("invalid length")
+		return "", "", ErrInvalidLengthError
 	}
 
 	// Extract the 32-byte public key

--- a/packages/core-go/muxed/encode.go
+++ b/packages/core-go/muxed/encode.go
@@ -2,17 +2,16 @@ package muxed
 
 import (
 	"encoding/binary"
-	"fmt"
 	"github.com/stellar-address-kit/core-go/address"
 )
 
 func EncodeMuxed(baseG string, id uint64) (string, error) {
 	versionByte, pubkey, err := address.DecodeStrKey(baseG)
 	if err != nil {
-		return "", fmt.Errorf("invalid G address: %w", err)
+		return "", NewInvalidGAddressError(err)
 	}
 	if versionByte != address.VersionByteG {
-		return "", fmt.Errorf("invalid G address")
+		return "", ErrInvalidGAddressError
 	}
 
 	payload := make([]byte, 40)

--- a/packages/core-go/muxed/errors.go
+++ b/packages/core-go/muxed/errors.go
@@ -1,0 +1,47 @@
+package muxed
+
+import "fmt"
+
+// ErrorCode represents a muxed address error code
+type ErrorCode string
+
+const (
+	ErrInvalidGAddress   ErrorCode = "INVALID_G_ADDRESS"
+	ErrUnknownVersionByte ErrorCode = "UNKNOWN_VERSION_BYTE"
+	ErrInvalidLength     ErrorCode = "INVALID_LENGTH"
+)
+
+// AddressError represents a muxed address-related error
+type AddressError struct {
+	Code    ErrorCode
+	Input   string
+	Message string
+	Cause   error
+}
+
+func (e *AddressError) Error() string {
+	if e.Cause != nil {
+		return fmt.Sprintf("%s: %v", e.Message, e.Cause)
+	}
+	return e.Message
+}
+
+func (e *AddressError) Unwrap() error {
+	return e.Cause
+}
+
+// Predefined muxed address errors
+var (
+	ErrInvalidGAddressError    = &AddressError{Code: ErrInvalidGAddress, Message: "invalid G address"}
+	ErrUnknownVersionByteError = &AddressError{Code: ErrUnknownVersionByte, Message: "unknown version byte"}
+	ErrInvalidLengthError      = &AddressError{Code: ErrInvalidLength, Message: "invalid length"}
+)
+
+// NewInvalidGAddressError creates an AddressError with a cause for invalid G address
+func NewInvalidGAddressError(cause error) *AddressError {
+	return &AddressError{
+		Code:    ErrInvalidGAddress,
+		Message: "invalid G address",
+		Cause:   cause,
+	}
+}


### PR DESCRIPTION
- Create errors.go with AddressError type and ErrorCode constants
- Add predefined error variables for programmatic error handling
- Implement Error() and Unwrap() methods for error inspection
- Update encode.go and decode.go to use named error types

Fixes #85