### PR TITLE
feat: add RoutingSource enum for routing metadata origin

### DIFF
--- a/packages/core-dart/lib/src/routing/result.dart
+++ b/packages/core-dart/lib/src/routing/result.dart
@@ -1,5 +1,8 @@
 import '../address/codes.dart';
 
+enum RoutingSource { muxed, memo, none }
+
+
 class RoutingInput {
   final String destination;
   final String memoType;
@@ -59,3 +62,4 @@ class RoutingWarning {
   @override
   int get hashCode => code.hashCode;
 }
+


### PR DESCRIPTION
Adds a `RoutingSource` enum representing routing metadata origin.

Closes #67