### PR TITLE
feat(routing): add Warning struct and WarningMemoIgnored constant

### DIFF
--- a/packages/core-go/routing/types.go
+++ b/packages/core-go/routing/types.go
@@ -1,0 +1,7 @@
+package routing
+
+type Warning struct {
+	Code string
+}
+
+const WarningMemoIgnored = "memo-ignored"


### PR DESCRIPTION
Summary
Adds a minimal Warning struct and a standardized routing warning constant.

Changes
Introduced Warning struct with Code field
Added WarningMemoIgnored constant ("memo-ignored")
Scope
No changes to existing logic or behavior.

Closes https://github.com/Boxkit-Labs/stellar-address-kit/issues/87