### PR TITLE
test(core-dart): add unit test for MuxedAddress encoding with id=0

### DIFF
--- a/packages/core-dart/test/muxed_test.dart
+++ b/packages/core-dart/test/muxed_test.dart
@@ -1,0 +1,18 @@
+import 'package:test/test.dart';
+import 'package:stellar_address_kit/stellar_address_kit.dart';
+
+void main() {
+  group('MuxedAddress.encode', () {
+    // Shared base G address used across encoding tests
+    const baseG = 'GAYCUYT553C5LHVE2XPW5GMEJT4BXGM7AHMJWLAPZP53KJO7EIQADRSI';
+
+    test('encodes id=0 (minimum uint64 boundary)', () {
+      const expected =
+          'MAYCUYT553C5LHVE2XPW5GMEJT4BXGM7AHMJWLAPZP53KJO7EIQACAAAAAAAAAAAAD672';
+
+      final result = MuxedAddress.encode(baseG: baseG, id: BigInt.zero);
+
+      expect(result, equals(expected));
+    });
+  });
+}


### PR DESCRIPTION
---

**test(core-dart): add unit test for MuxedAddress encoding with id=0**

**What**
Adds `packages/core-dart/test/muxed_test.dart` with an explicit unit test for `MuxedAddress.encode` when `id = BigInt.zero`.

**Why**
`id=0` is the minimum uint64 boundary. It's a known edge case that can silently break serialization — specifically, missing zero-padding in the 8-byte big-endian ID field or an off-by-one in the loop that writes the ID bytes. Without an explicit test, this case is only covered indirectly through the spec runner.

**How**
The expected muxed strkey is taken directly from `spec/vectors.json` (the canonical source of truth for this repo), so the assertion is authoritative and not hand-rolled.

**Test**
```
dart test test/muxed_test.dart
```

Closes #64

---

The test lives at `packages/core-dart/test/muxed_test.dart`, uses the same `baseG` and expected `mAddress` from `spec/vectors.json`, and follows the same patterns as `spec_runner_test.dart`.
