### PR TITLE
Fix parse exception behavior and add StellarAddressException tests

### DIFF
--- a/packages/core-dart/lib/src/address/detect.dart
+++ b/packages/core-dart/lib/src/address/detect.dart
@@ -12,21 +12,26 @@ AddressKind? detect(String address) {
     final decoded = StrKeyUtil.decodeBase32(address);
     if (decoded.length < 3) return null;
 
-    final data = decoded.sublist(0, decoded.length - 2);
+    final payload = decoded.sublist(0, decoded.length - 2);
     final checksum = decoded.sublist(decoded.length - 2);
-    final calculated = StrKeyUtil.calculateChecksum(Uint8List.fromList(data));
+    final calculated = StrKeyUtil.calculateChecksum(Uint8List.fromList(payload));
 
     if (checksum[0] != (calculated & 0xFF) ||
         checksum[1] != ((calculated >> 8) & 0xFF)) {
       return null;
     }
 
+    // Enforce exact version and length for each kind.
+    final versionByte = payload[0];
     switch (prefix) {
       case 'G':
+        if (decoded.length != 35 || versionByte != 0x30) return null;
         return AddressKind.g;
       case 'M':
+        if (decoded.length != 43 || versionByte != 0x60) return null;
         return AddressKind.m;
       case 'C':
+        if (decoded.length != 35 || versionByte != 0x10) return null;
         return AddressKind.c;
       default:
         return null;

--- a/packages/core-dart/lib/src/address/stellar_address.dart
+++ b/packages/core-dart/lib/src/address/stellar_address.dart
@@ -40,13 +40,18 @@ class StellarAddress {
         return StellarAddress._(
             kind: AddressKind.g, raw: address, baseG: address);
       case AddressKind.m:
-        final decoded = MuxedDecoder.decodeMuxedString(address);
-        return StellarAddress._(
-          kind: AddressKind.m,
-          raw: address,
-          baseG: decoded['baseG'] as String?,
-          muxedId: decoded['id'] as BigInt?,
-        );
+        try {
+          final decoded = MuxedDecoder.decodeMuxedString(address);
+          return StellarAddress._(
+            kind: AddressKind.m,
+            raw: address,
+            baseG: decoded['baseG'] as String?,
+            muxedId: decoded['id'] as BigInt?,
+          );
+        } catch (error, stackTrace) {
+          throw StellarAddressException(
+              'Invalid muxed address: ${error.toString()}');
+        }
       case AddressKind.c:
         return StellarAddress._(kind: AddressKind.c, raw: address);
     }

--- a/packages/core-dart/test/address_test.dart
+++ b/packages/core-dart/test/address_test.dart
@@ -1,0 +1,33 @@
+import 'package:test/test.dart';
+import 'package:stellar_address_kit/stellar_address_kit.dart';
+
+void main() {
+  group('StellarAddress.parse', () {
+    test('throws StellarAddressException for invalid strkey', () {
+      // Invalid because checksum and/or length are incorrect.
+      const invalidAddress = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+      expect(
+        () => StellarAddress.parse(invalidAddress),
+        throwsA(isA<StellarAddressException>()),
+      );
+    });
+
+    test('throws StellarAddressException for unexpected characters', () {
+      // Contains non-base32 characters like '!' and spaces which are invalid in strkey.
+      const invalidAddress = 'GInvalid!@@@@@O000000000000000000000000000000000000';
+      expect(
+        () => StellarAddress.parse(invalidAddress),
+        throwsA(isA<StellarAddressException>()),
+      );
+    });
+
+    test('throws StellarAddressException for invalid muxed address form', () {
+      // M prefix but wrong length/payload, should not silently produce range errors.
+      const invalidMuxed = 'MAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+      expect(
+        () => StellarAddress.parse(invalidMuxed),
+        throwsA(isA<StellarAddressException>()),
+      );
+    });
+  });
+}


### PR DESCRIPTION
Closes #60

---

closes issue #60 

## Summary

This PR enforces explicit invalid-address behavior in `core-dart` and adds regression tests to validate dedicated exception handling.

### Code changes

- `packages/core-dart/lib/src/address/detect.dart`
  - Enforces:
    - prefix in `G`, `M`, `C`
    - correct base32 decoding
    - checksum validation
    - exact lengths:
      - `G`/`C`: 35 bytes decode
      - `M`: 43 bytes decode
    - version byte:
      - `G` = 0x30
      - `M` = 0x60
      - `C` = 0x10

- `packages/core-dart/lib/src/address/stellar_address.dart`
  - `StellarAddress.parse(...)`:
    - still throws `StellarAddressException('Invalid address')` when kind is `null`
    - wraps `MuxedDecoder.decodeMuxedString(...)` in `try/catch` and rethrows as `StellarAddressException(...)`

### Tests added

- New file:
  - `packages/core-dart/test/address_test.dart`

- New tests:
  - Invalid strkey format (bad checksum/length)
  - Invalid non-base32 characters
  - Invalid muxed address form (`M...` with wrong length/payload)

All tests assert:
- `throwsA(isA<StellarAddressException>())`

---

## 🧪 Verification

Run locally:
```bash
cd packages/core-dart
dart test