### PR TITLE
feat(core-dart): add toDisplayString() to RoutingSource enum with uni…

### DIFF
--- a/packages/core-dart/lib/src/routing/result.dart
+++ b/packages/core-dart/lib/src/routing/result.dart
@@ -1,6 +1,21 @@
 import '../address/codes.dart';
 
-enum RoutingSource { muxed, memo, none }
+enum RoutingSource {
+  muxed,
+  memo,
+  none;
+
+  String toDisplayString() {
+    switch (this) {
+      case RoutingSource.muxed:
+        return 'Routed via muxed address (M-address)';
+      case RoutingSource.memo:
+        return 'Routed via memo ID';
+      case RoutingSource.none:
+        return 'No routing source detected';
+    }
+  }
+}
 
 
 class RoutingInput {

--- a/packages/core-dart/test/routing_test.dart
+++ b/packages/core-dart/test/routing_test.dart
@@ -1,0 +1,27 @@
+import 'package:test/test.dart';
+import 'package:stellar_address_kit/stellar_address_kit.dart';
+
+void main() {
+  group('RoutingSource.toDisplayString', () {
+    test('muxed variant formats as muxed address display string', () {
+      expect(
+        RoutingSource.muxed.toDisplayString(),
+        equals('Routed via muxed address (M-address)'),
+      );
+    });
+
+    test('memo variant formats as memo ID display string', () {
+      expect(
+        RoutingSource.memo.toDisplayString(),
+        equals('Routed via memo ID'),
+      );
+    });
+
+    test('none variant formats as no routing source display string', () {
+      expect(
+        RoutingSource.none.toDisplayString(),
+        equals('No routing source detected'),
+      );
+    });
+  });
+}


### PR DESCRIPTION
---

**Branch:** `feat/routing-source-display-string-tests`

**PR Title:** `feat(core-dart): add toDisplayString() to RoutingSource enum with unit tests`

**Description:**

Closes #75

`RoutingSource` was a bare enum with no display contract, making it easy for future changes to silently break formatted output. This PR adds `toDisplayString()` directly on the enum and covers all three variants with explicit unit tests.

Changes:
- `lib/src/routing/result.dart` — added `toDisplayString()` method to `RoutingSource` enum covering `muxed`, `memo`, and `none`
- `test/routing_test.dart` — 3 bound assert tests, one per variant, verifying exact display string output

Each test asserts a structurally distinct string so no two variants can collapse to the same output without a test failing.

---

To run the tests locally:
```bash
cd packages/core-dart
dart test test/routing_test.dart
```