### PR TITLE
fix: use RangeError for uint64 range validation in encodeMuxed (#117)

### DIFF
--- a/packages/core-ts/src/muxed/encode.test.ts
+++ b/packages/core-ts/src/muxed/encode.test.ts
@@ -61,4 +61,24 @@ describe("encodeMuxed", () => {
       );
     }).toThrow("ID must be a bigint");
   });
+
+  // 5. Boundary Values: Valid edge cases
+  it("accepts id=0n (minimum valid uint64)", () => {
+    expect(() => {
+      encodeMuxed(
+        "GAYCUYT553C5LHVE2XPW5GMEJT4BXGM7AHMJWLAPZP53KJO7EIQADRSI",
+        0n,
+      );
+    }).not.toThrow();
+  });
+
+  it("accepts id=MAX_UINT64 (maximum valid uint64)", () => {
+    const MAX_UINT64 = 18446744073709551615n;
+    expect(() => {
+      encodeMuxed(
+        "GAYCUYT553C5LHVE2XPW5GMEJT4BXGM7AHMJWLAPZP53KJO7EIQADRSI",
+        MAX_UINT64,
+      );
+    }).not.toThrow();
+  });
 });

--- a/packages/core-ts/src/muxed/encode.ts
+++ b/packages/core-ts/src/muxed/encode.ts
@@ -8,7 +8,7 @@ export function encodeMuxed(baseG: string, id: bigint): string {
   }
 
   if (id < 0n || id > MAX_UINT64) {
-    throw new Error(`ID is outside the uint64 range: ${id.toString()}`);
+    throw new RangeError(`ID is outside the uint64 range: ${id.toString()}`);
   }
 
   if (StrKey.isValidEd25519PublicKey(baseG) === false) {


### PR DESCRIPTION
The core bigint range validation was already implemented prior to this 
issue being assigned. This PR improves the existing implementation by:

- Aligning the error type with the issue requirement (`RangeError`)
- Adding boundary tests for `0n` and `MAX_UINT64`


## Tests
7/7 passing

Close #117 