### PR TITLE
feat: Implemented Add unit test for MuxedAddress encoding with ID above 2^53

### DIFF
--- a/packages/core-dart/test/muxed_test.dart
+++ b/packages/core-dart/test/muxed_test.dart
@@ -14,5 +14,20 @@ void main() {
 
       expect(result, equals(expected));
     });
+
+    test('encodes id above 2^53 (9007199254740993) without truncation', () {
+      // ID = 2^53 + 1 = 9007199254740993, which exceeds JavaScript's
+      // safe integer limit (2^53 - 1). BigInt must be used to avoid
+      // floating-point precision loss when encoding to uint64.
+      const expected =
+          'MAYCUYT553C5LHVE2XPW5GMEJT4BXGM7AHMJWLAPZP53KJO7EIQACABAAAAAAAAAAEVIG';
+
+      final result = MuxedAddress.encode(
+        baseG: baseG,
+        id: BigInt.parse('9007199254740993'),
+      );
+
+      expect(result, equals(expected));
+    });
   });
 }


### PR DESCRIPTION
Closes #65 
Done! The test has been pushed to your repo. Here's the PR description you can use:

**Title:** test: Add unit test for MuxedAddress encoding with ID above 2^53

**Body:**

This PR adds a unit test to verify that the MuxedAddress encoding logic correctly handles IDs exceeding JavaScript's safe integer limit (2^53 - 1).

**Changes:**
- Added test case in `packages/core-dart/test/muxed_test.dart` that encodes ID `BigInt.parse('9007199254740993')` (2^53 + 1)
- The test ensures BigInt usage correctly bypasses JS integer precision limits on Dart compilation paths
- Uses the expected value from the spec vectors to verify correct encoding

**Why this matters:**
IDs above 2^53 - 1 would cause silent floating-point truncation if encoded as standard JavaScript numbers. The test confirms that the Dart implementation properly uses BigInt to handle these large IDs without precision loss.

**Testing:**
- Verified against spec vectors: `MAYCUYT553C5LHVE2XPW5GMEJT4BXGM7AHMJWLAPZP53KJO7EIQACABAAAAAAAAAAEVIG`