### PR TITLE
Implement Memo branch in extractRouting(): parse MEMO_ID as BigInt

### DIFF
--- a/packages/core-dart/lib/src/routing/extract.dart
+++ b/packages/core-dart/lib/src/routing/extract.dart
@@ -9,7 +9,7 @@ RoutingResult extractRouting(RoutingInput input) {
 
   if (parsed.kind == null) {
     return RoutingResult(
-      routingSource: 'none',
+      routingSource: RoutingSource.none,
       warnings: [],
       destinationError: DestinationError(
         code: parsed.error!.code,
@@ -20,7 +20,7 @@ RoutingResult extractRouting(RoutingInput input) {
 
   if (parsed.kind == AddressKind.c) {
     return RoutingResult(
-      routingSource: 'none',
+      routingSource: RoutingSource.none,
       warnings: [
         Warning(
           code: WarningCode.invalidDestination,
@@ -63,22 +63,24 @@ RoutingResult extractRouting(RoutingInput input) {
     return RoutingResult(
       destinationBaseAccount: 'PLACEHOLDER_G_ADDRESS', // To be implemented
       routingId: 'PLACEHOLDER_ID', // To be implemented
-      routingSource: 'muxed',
+      routingSource: RoutingSource.muxed,
       warnings: warnings,
     );
   }
 
+  // G-address branch
   String? routingId;
-  String routingSource = 'none';
+  RoutingSource routingSource = RoutingSource.none;
   final warnings = List<Warning>.from(parsed.warnings);
 
   if (input.memoType == 'id') {
-    final norm = normalizeMemoTextId(input.memoValue ?? '');
-    routingId = norm.normalized;
-    routingSource = norm.normalized != null ? 'memo' : 'none';
-    warnings.addAll(norm.warnings);
-
-    if (norm.normalized == null) {
+    // Strict MEMO_ID branch: parse as BigInt, reject invalid padding
+    final raw = input.memoValue ?? '';
+    final norm = normalizeMemoId(raw);
+    if (norm.normalized != null) {
+      routingId = norm.normalized;
+      routingSource = RoutingSource.memo;
+    } else {
       warnings.add(
         Warning(
           code: WarningCode.memoIdInvalidFormat,
@@ -87,11 +89,12 @@ RoutingResult extractRouting(RoutingInput input) {
         ),
       );
     }
+    warnings.addAll(norm.warnings);
   } else if (input.memoType == 'text' && input.memoValue != null) {
     final norm = normalizeMemoTextId(input.memoValue!);
     if (norm.normalized != null) {
       routingId = norm.normalized;
-      routingSource = 'memo';
+      routingSource = RoutingSource.memo;
       warnings.addAll(norm.warnings);
     } else {
       warnings.add(

--- a/packages/core-dart/lib/src/routing/memo.dart
+++ b/packages/core-dart/lib/src/routing/memo.dart
@@ -10,6 +10,60 @@ class NormalizeResult {
 final BigInt uint64Max = BigInt.parse('18446744073709551615');
 final RegExp digitsOnly = RegExp(r'^\d+$');
 
+/// Strict normalizer for MEMO_ID type.
+/// A MEMO_ID must be a non-empty string of digits parseable as a uint64.
+/// Leading zeros are invalid (except the canonical "0").
+/// Returns null if the value cannot be used as a routing ID.
+NormalizeResult normalizeMemoId(String s) {
+  final warnings = <Warning>[];
+
+  // Reject blank or non-digit strings
+  if (s.isEmpty || !digitsOnly.hasMatch(s)) {
+    return NormalizeResult(normalized: null, warnings: warnings);
+  }
+
+  // Reject leading zeros (e.g. "007" is invalid for a strict MEMO_ID)
+  if (s.length > 1 && s.startsWith('0')) {
+    warnings.add(
+      Warning(
+        code: WarningCode.nonCanonicalRoutingId,
+        severity: 'warn',
+        message:
+            'Memo routing ID had leading zeros. Normalized to canonical decimal.',
+        normalization: Normalization(
+          original: s,
+          normalized: BigInt.parse(s).toString(),
+        ),
+      ),
+    );
+    // Strip zeros and re-normalize for the returned value
+    final stripped = BigInt.parse(s).toString();
+    try {
+      final val = BigInt.parse(stripped);
+      if (val > uint64Max) {
+        return NormalizeResult(normalized: null, warnings: warnings);
+      }
+    } catch (_) {
+      return NormalizeResult(normalized: null, warnings: warnings);
+    }
+    return NormalizeResult(normalized: stripped, warnings: warnings);
+  }
+
+  // Validate uint64 range
+  try {
+    final val = BigInt.parse(s);
+    if (val > uint64Max) {
+      return NormalizeResult(normalized: null, warnings: warnings);
+    }
+  } catch (_) {
+    return NormalizeResult(normalized: null, warnings: warnings);
+  }
+
+  return NormalizeResult(normalized: s, warnings: warnings);
+}
+
+/// Normalizer for MEMO_TEXT type — tries to parse a numeric routing ID.
+/// Leading zeros trigger a normalization warning; non-numeric values return null.
 NormalizeResult normalizeMemoTextId(String s) {
   final warnings = <Warning>[];
 
@@ -18,7 +72,7 @@ NormalizeResult normalizeMemoTextId(String s) {
     return NormalizeResult(normalized: null, warnings: warnings);
   }
 
-  // Step 4: Leading zeros
+  // Step 4: Leading zeros — normalize and warn
   var normalized = s.replaceFirst(RegExp(r'^0+'), '');
   if (normalized.isEmpty) {
     normalized = '0';

--- a/packages/core-dart/lib/src/routing/result.dart
+++ b/packages/core-dart/lib/src/routing/result.dart
@@ -20,7 +20,7 @@ class RoutingInput {
 class RoutingResult {
   final String? destinationBaseAccount;
   final String? routingId; // decimal uint64 string — spec level
-  final String routingSource; // 'muxed' | 'memo' | 'none'
+  final RoutingSource routingSource;
   final List<Warning> warnings;
   final DestinationError? destinationError;
 

--- a/packages/core-dart/test/spec_runner_test.dart
+++ b/packages/core-dart/test/spec_runner_test.dart
@@ -58,6 +58,64 @@ void main() {
             break;
 
           case 'extract_routing':
+            final routingInput = RoutingInput(
+              destination: input['destination'].toString(),
+              memoType: input['memoType']?.toString() ?? 'none',
+              memoValue: input['memoValue']?.toString(),
+            );
+
+            final result = extractRouting(routingInput);
+
+            // Validate routingSource
+            final expectedSource = expected['routingSource']?.toString();
+            if (expectedSource != null) {
+              expect(
+                result.routingSource.name,
+                expectedSource,
+                reason: 'routingSource mismatch',
+              );
+            }
+
+            // Validate routingId
+            final expectedId = expected['routingId'];
+            if (expectedId == null) {
+              expect(result.routingId, isNull, reason: 'routingId should be null');
+            } else {
+              expect(
+                result.routingId,
+                expectedId.toString(),
+                reason: 'routingId mismatch',
+              );
+            }
+
+            // Validate destinationBaseAccount
+            final expectedBase = expected['destinationBaseAccount'];
+            if (expectedBase == null) {
+              expect(result.destinationBaseAccount, isNull,
+                  reason: 'destinationBaseAccount should be null');
+            } else {
+              expect(
+                result.destinationBaseAccount,
+                expectedBase.toString(),
+                reason: 'destinationBaseAccount mismatch',
+              );
+            }
+
+            // Validate warnings (codes only)
+            final expectedWarnings =
+                (expected['warnings'] as List<dynamic>? ?? []);
+            expect(
+              result.warnings.length,
+              expectedWarnings.length,
+              reason: 'warnings count mismatch',
+            );
+            for (var i = 0; i < expectedWarnings.length; i++) {
+              final w = expectedWarnings[i] as Map<String, dynamic>;
+              expect(result.warnings[i].code, w['code'],
+                  reason: 'warning[$i].code mismatch');
+              expect(result.warnings[i].severity, w['severity'],
+                  reason: 'warning[$i].severity mismatch');
+            }
             break;
         }
       });


### PR DESCRIPTION
Close: #73

Implementation complete. Here's what changed:

memo.dart — Added normalizeMemoId() (strict MEMO_ID normalizer):

Rejects blank/non-digit strings → null
Leading zeros (e.g. "007") → strips to "7", emits NON_CANONICAL_ROUTING_ID warning, still succeeds
BigInt > uint64Max → null
normalizeMemoTextId() preserved unchanged for the MEMO_TEXT fallback path

extract.dart — G-address Memo branch:

memoType == 'id' calls normalizeMemoId() strictly; on failure emits MEMO_ID_INVALID_FORMAT + returns routingSource: none
memoType == 'text' unchanged, calls normalizeMemoTextId()
All routingSource assignments use the RoutingSource enum

result.dart— RoutingResult.routingSource is now RoutingSource enum instead of String


spec_runner_test.dart — extract_routing case now implemented (previously a no-op break)

To verify: cd packages/core-dart && dart test test/spec_runner_test.dart