### PR TITLE
Fix/decode muxed use sdk primitive

### DIFF
--- a/packages/core-ts/src/muxed/decode.ts
+++ b/packages/core-ts/src/muxed/decode.ts
@@ -1,56 +1,5 @@
-import StellarSdk from "@stellar/stellar-sdk";
+import { MuxedAccount } from "@stellar/stellar-sdk";
 import { MuxedResult } from "./types";
-
-const { StrKey } = StellarSdk;
-
-const BASE32_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
-
-function decodeBase32(input: string): Uint8Array {
-  const s = input.toUpperCase().replace(/=+$/, "");
-  const byteCount = Math.floor((s.length * 5) / 8);
-  const result = new Uint8Array(byteCount);
-  let buffer = 0;
-  let bitsLeft = 0;
-  let byteIndex = 0;
-  for (const ch of s) {
-    const value = BASE32_CHARS.indexOf(ch);
-    if (value === -1) throw new Error(`Invalid base32 character: ${ch}`);
-    buffer = (buffer << 5) | value;
-    bitsLeft += 5;
-    if (bitsLeft >= 8) {
-      if (byteIndex < byteCount) {
-        result[byteIndex++] = (buffer >> (bitsLeft - 8)) & 0xff;
-      }
-      bitsLeft -= 8;
-    }
-  }
-  return result;
-}
-
-function crc16(bytes: Uint8Array): number {
-  let crc = 0;
-  for (const byte of bytes) {
-    crc ^= byte << 8;
-    for (let i = 0; i < 8; i++) {
-      crc = crc & 0x8000 ? (crc << 1) ^ 0x1021 : crc << 1;
-    }
-  }
-  return crc & 0xffff;
-}
-
-function decodeStrKey(address: string): Uint8Array {
-  const up = address.toUpperCase();
-  const decoded = decodeBase32(up);
-  if (decoded.length < 3) throw new Error("invalid encoded string");
-
-  const data = decoded.slice(0, decoded.length - 2);
-  const checksum =
-    decoded[decoded.length - 2] | (decoded[decoded.length - 1] << 8);
-  const computed = crc16(data);
-  if (computed !== checksum) throw new Error("invalid checksum");
-
-  return data;
-}
 
 /**
  * Decodes a Stellar muxed address (M-address).
@@ -59,20 +8,9 @@ function decodeStrKey(address: string): Uint8Array {
  * @returns {baseG: string, id: bigint}
  */
 export function decodeMuxed(mAddress: string): MuxedResult {
-  const data = decodeStrKey(mAddress);
-  // Layout: [Version(1)] [Pubkey(32)] [ID(8)]
-  if (data.length !== 41) throw new Error("invalid payload length");
-
-  const pubkey = data.slice(1, 33);
-  const idBytes = data.slice(33, 41);
-
-  let id = 0n;
-  for (const byte of idBytes) {
-    id = (id << 8n) + BigInt(byte);
-  }
-
+  const muxed = MuxedAccount.fromAddress(mAddress, "0");
   return {
-    baseG: StrKey.encodeEd25519PublicKey(pubkey),
-    id,
+    baseG: muxed.baseAccount().accountId(),
+    id: BigInt(muxed.id()),
   };
 }


### PR DESCRIPTION
## Summary

- Replaced custom base32 decoding, CRC16 checksum validation, and byte manipulation with `MuxedAccount.fromAddress()` from the Stellar SDK
- Removed 60 lines of custom parsing code in favor of a single SDK call
- Maintains full backward compatibility with existing function signature

## Root Cause

The previous implementation duplicated parsing logic already available in the Stellar SDK's `MuxedAccount.fromAddress()` method. Using custom parsing introduces potential vulnerabilities if the implementation diverges from the canonical SDK behavior.

## Fix Implemented

Refactored `decodeMuxed` to:
1. Parse the M-address using `MuxedAccount.fromAddress(mAddress, "0")`
2. Extract the base G-address via `muxed.baseAccount().accountId()`
3. Extract the ID via `muxed.id()`

## Testing Performed

- All 62 existing tests pass
- Normative vector tests for `muxed_decode` module all pass
- Build completes successfully

Closes #120