### PR TITLE
Added the routing Id point unit64 for the result struct

### DIFF
--- a/packages/core-go/routing/extract.go
+++ b/packages/core-go/routing/extract.go
@@ -2,6 +2,7 @@ package routing
 
 import (
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/stellar-address-kit/core-go/address"
@@ -108,20 +109,21 @@ func ExtractRouting(input RoutingInput) RoutingResult {
 
 		return RoutingResult{
 			DestinationBaseAccount: baseG,
-			RoutingID:              id,
+			RoutingID:              &id,
 			RoutingSource:          "muxed",
 			Warnings:               warnings,
 		}
 	}
 
-	routingID := ""
+	routingID := (*uint64)(nil)
 	routingSource := "none"
 	warnings := []address.Warning{}
 
 	if input.MemoType == "id" {
 		norm := NormalizeMemoTextID(input.MemoValue)
-		routingID = norm.Normalized
 		if norm.Normalized != "" {
+			parsedID, _ := strconv.ParseUint(norm.Normalized, 10, 64)
+			routingID = &parsedID
 			routingSource = "memo"
 		}
 		warnings = append(warnings, norm.Warnings...)
@@ -136,7 +138,8 @@ func ExtractRouting(input RoutingInput) RoutingResult {
 	} else if input.MemoType == "text" && input.MemoValue != "" {
 		norm := NormalizeMemoTextID(input.MemoValue)
 		if norm.Normalized != "" {
-			routingID = norm.Normalized
+			parsedID, _ := strconv.ParseUint(norm.Normalized, 10, 64)
+			routingID = &parsedID
 			routingSource = "memo"
 			warnings = append(warnings, norm.Warnings...)
 		} else {

--- a/packages/core-go/routing/extract_test.go
+++ b/packages/core-go/routing/extract_test.go
@@ -26,7 +26,7 @@ func TestExtractRouting_RoutingMatrix(t *testing.T) {
 			},
 			expected: RoutingResult{
 				DestinationBaseAccount: testBaseG,
-				RoutingID:              "",
+				RoutingID:              nil,
 				RoutingSource:          "none",
 				Warnings:               []address.Warning{},
 			},
@@ -40,7 +40,7 @@ func TestExtractRouting_RoutingMatrix(t *testing.T) {
 			},
 			expected: RoutingResult{
 				DestinationBaseAccount: testBaseG,
-				RoutingID:              "100",
+				RoutingID:              ptrUint64(100),
 				RoutingSource:          "memo",
 				Warnings:               []address.Warning{},
 			},
@@ -54,7 +54,7 @@ func TestExtractRouting_RoutingMatrix(t *testing.T) {
 			},
 			expected: RoutingResult{
 				DestinationBaseAccount: testBaseG,
-				RoutingID:              "7",
+				RoutingID:              ptrUint64(7),
 				RoutingSource:          "memo",
 				Warnings: []address.Warning{
 					{
@@ -78,7 +78,7 @@ func TestExtractRouting_RoutingMatrix(t *testing.T) {
 			},
 			expected: RoutingResult{
 				DestinationBaseAccount: testBaseG,
-				RoutingID:              "",
+				RoutingID:              nil,
 				RoutingSource:          "none",
 				Warnings: []address.Warning{
 					{
@@ -101,7 +101,7 @@ func TestExtractRouting_RoutingMatrix(t *testing.T) {
 			},
 			expected: RoutingResult{
 				DestinationBaseAccount: testBaseG,
-				RoutingID:              "",
+				RoutingID:              nil,
 				RoutingSource:          "none",
 				Warnings: []address.Warning{
 					{
@@ -123,7 +123,7 @@ func TestExtractRouting_RoutingMatrix(t *testing.T) {
 			},
 			expected: RoutingResult{
 				DestinationBaseAccount: testBaseG,
-				RoutingID:              "9007199254740993",
+				RoutingID:              ptrUint64(9007199254740993),
 				RoutingSource:          "muxed",
 				Warnings:               []address.Warning{},
 			},
@@ -137,7 +137,7 @@ func TestExtractRouting_RoutingMatrix(t *testing.T) {
 			},
 			expected: RoutingResult{
 				DestinationBaseAccount: testBaseG,
-				RoutingID:              "9007199254740993",
+				RoutingID:              ptrUint64(9007199254740993),
 				RoutingSource:          "muxed",
 				Warnings: []address.Warning{
 					{
@@ -157,7 +157,7 @@ func TestExtractRouting_RoutingMatrix(t *testing.T) {
 			},
 			expected: RoutingResult{
 				DestinationBaseAccount: testBaseG,
-				RoutingID:              "9007199254740993",
+				RoutingID:              ptrUint64(9007199254740993),
 				RoutingSource:          "muxed",
 				Warnings: []address.Warning{
 					{
@@ -204,13 +204,17 @@ func TestExtractRouting_ContractSourceClearsRoutingState(t *testing.T) {
 	assertRoutingResult(t, result, expected)
 }
 
+func ptrUint64(v uint64) *uint64 {
+	return &v
+}
+
 func assertRoutingResult(t *testing.T, got, want RoutingResult) {
 	t.Helper()
 
 	if got.DestinationBaseAccount != want.DestinationBaseAccount {
 		t.Errorf("DestinationBaseAccount = %v, want %v", got.DestinationBaseAccount, want.DestinationBaseAccount)
 	}
-	if got.RoutingID != want.RoutingID {
+	if !uint64PtrEqual(got.RoutingID, want.RoutingID) {
 		t.Errorf("RoutingID = %v, want %v", got.RoutingID, want.RoutingID)
 	}
 	if got.RoutingSource != want.RoutingSource {
@@ -222,4 +226,14 @@ func assertRoutingResult(t *testing.T, got, want RoutingResult) {
 	if !reflect.DeepEqual(got.DestinationError, want.DestinationError) {
 		t.Errorf("DestinationError = %#v, want %#v", got.DestinationError, want.DestinationError)
 	}
+}
+
+func uint64PtrEqual(a, b *uint64) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return *a == *b
 }

--- a/packages/core-go/routing/types.go
+++ b/packages/core-go/routing/types.go
@@ -23,7 +23,7 @@ type RoutingResult struct {
 
 	// Backward-compatible fields used by current extraction flow.
 	DestinationBaseAccount string            `json:"destinationBaseAccount,omitempty"`
-	RoutingID              string            `json:"routingId,omitempty"`
+	RoutingID              *uint64           `json:"routingId,omitempty"`
 	RoutingSource          string            `json:"routingSource,omitempty"`
 	Warnings               []address.Warning `json:"warnings,omitempty"`
 	DestinationError       *DestinationError `json:"destinationError,omitempty"`


### PR DESCRIPTION

Implemented the Ensure RoutingID is a pointer *uint64 in the result struct 

A standard 0 value could signify explicit route targeting, so Go requires pointers to validate absence independently from an explicit 0 value.

Implementation Guidelines
Key Files: packages/core-go/routing/types.go.

Change the id field in RoutingResult to *uint64 so it can represent nil.
Expectations
What done looks like: The result accurately differentiates between "no ID provided" and "ID is zero".

closes #88
