### PR TITLE
Add JSDoc to encodeMuxed() with @throws and @param tags

### DIFF
--- a/packages/core-ts/src/muxed/encode.ts
+++ b/packages/core-ts/src/muxed/encode.ts
@@ -4,6 +4,16 @@ const { Account, MuxedAccount, StrKey } = StellarSdk;
 
 const MAX_UINT64 = 18446744073709551615n;
 
+/**
+ * Encodes a muxed Stellar address using a base G address and numeric ID.
+ *
+ * @param baseG - The base G address (Ed25519 public key) to mux with
+ * @param id - The numeric ID to append to the base address (must be uint64)
+ * @returns The encoded muxed address string
+ * @throws {TypeError} When the ID parameter is not a bigint
+ * @throws {RangeError} When the ID is outside the uint64 range (0 to 18446744073709551615)
+ * @throws {Error} When the base G address is not a valid Ed25519 public key
+ */
 export function encodeMuxed(baseG: string, id: bigint): string {
   if (typeof id !== "bigint") {
     throw new TypeError(`ID must be a bigint, received ${typeof id}`);


### PR DESCRIPTION
Closes #125



Add comprehensive JSDoc documentation to encodeMuxed() function with proper parameter descriptions, return type, and all potential thrown errors. This improves IDE tooltips and API discoverability for consumers.

Changes:

Added JSDoc block with @param, @returns, and @throws tags
Documented TypeError for invalid bigint parameter
Documented RangeError for uint64 boundary violations
Documented Error for invalid Ed25519 public keys
Closes #125