### PR TITLE
test: validate contract address kind parsing (#59)

### DIFF
--- a/packages/core-dart/test/address_test.dart
+++ b/packages/core-dart/test/address_test.dart
@@ -14,7 +14,7 @@ void main() {
 
     test('throws StellarAddressException for unexpected characters', () {
       // Contains non-base32 characters like '!' and spaces which are invalid in strkey.
-      const invalidAddress = 'GInvalid!@@@@@O000000000000000000000000000000000000';
+      const invalidAddress = 'GInvalid!@@@@@@O000000000000000000000000000000000000000';
       expect(
         () => StellarAddress.parse(invalidAddress),
         throwsA(isA<StellarAddressException>()),
@@ -23,7 +23,7 @@ void main() {
 
     test('throws StellarAddressException for invalid muxed address form', () {
       // M prefix but wrong length/payload, should not silently produce range errors.
-      const invalidMuxed = 'MAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+      const invalidMuxed = 'MAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
       expect(
         () => StellarAddress.parse(invalidMuxed),
         throwsA(isA<StellarAddressException>()),
@@ -35,6 +35,14 @@ void main() {
           'GAYCUYT553C5LHVE2XPW5GMEJT4BXGM7AHMJWLAPZP53KJO7EIQADRSI';
       final result = StellarAddress.parse(validAddress);
       expect(result.kind, equals(AddressKind.g));
+    });
+
+    test('identifies kind as contract for valid contract address', () {
+      const validContractAddress =
+          'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4';
+      final result = StellarAddress.parse(validContractAddress);
+      expect(result.kind, equals(AddressKind.contract));
+      expect(result.value, equals(validContractAddress));
     });
   });
 }


### PR DESCRIPTION
Fixes #59

## Summary
- add a regression test for parsing valid contract `C...` addresses in the Dart core package
- assert that `StellarAddress.parse()` resolves the parsed address kind to `AddressKind.contract`
- keep the test alongside the existing parse behavior coverage in `packages/core-dart/test/address_test.dart`

## Testing
- Not run locally in this environment