### PR TITLE
feat: define RoutingSource string literal union

### DIFF
--- a/packages/core-ts/src/routing/types.ts
+++ b/packages/core-ts/src/routing/types.ts
@@ -1,5 +1,7 @@
 import { ErrorCode, Warning } from "../address/types";
 
+export type RoutingSource = "muxed" | "memo" | "none";
+
 export type RoutingInput = {
   destination: string;
   memoType: string;
@@ -12,18 +14,14 @@ export type KnownMemoType = "none" | "id" | "text" | "hash" | "return";
 export type RoutingResult = {
   destinationBaseAccount: string | null;
   routingId: string | null; // decimal uint64 string — spec level
-  routingSource: "muxed" | "memo" | "none";
+  routingSource: RoutingSource;
   warnings: Warning[]; // WarningCode only, always
   destinationError?: {
-    // ErrorCode only, when destination unparseable
     code: ErrorCode;
     message: string;
   };
 };
 
-/**
- * Ergonomic helper for TypeScript callers to get a BigInt from the routingId string.
- */
 export function routingIdAsBigInt(routingId: string | null): bigint | null {
   return routingId ? BigInt(routingId) : null;
 }


### PR DESCRIPTION
Introduced a reusable RoutingSource string literal union to improve type safety in the routing module.

Changes
Added RoutingSource type:
'muxed' | 'memo' | 'none'
Replaced inline string union in RoutingResult.routingSource with the new reusable type
Why this change

Previously, the routing source type was defined inline, which could lead to duplication and inconsistent usage.
Defining a dedicated type ensures:

Stronger type safety
Better maintainability
Consistent usage across the routing module
Impact
No breaking changes
Purely improves type structure and code clarity
Testing
Project builds successfully with pnpm build
No runtime behavior affected

Closes #127