### PR TITLE
 docs(core-dart): link muxed address docs to flutter web bigint guide

### DIFF
--- a/docs/guides/flutter-web-bigint.md
+++ b/docs/guides/flutter-web-bigint.md
@@ -1,0 +1,19 @@
+# Flutter Web BigInt Caveats
+
+When Dart is compiled to JavaScript for Flutter web, JavaScript number
+semantics apply at the interop boundary. That matters for Stellar muxed account
+IDs because muxed IDs are unsigned 64-bit integers and values above `2^53 - 1`
+cannot be represented safely as a JavaScript `Number`.
+
+## Guidance
+
+- Keep muxed IDs as Dart `BigInt` values for as long as possible.
+- Do not coerce muxed IDs into JavaScript `Number` values on web targets.
+- If you need to serialize or transmit a muxed ID in a web flow, prefer a
+  string representation and convert back to `BigInt` explicitly.
+
+## Why It Matters
+
+Precision loss in a muxed ID can route funds or metadata to the wrong account
+context. Treat muxed IDs as exact integers, not floating-point-compatible
+numbers.

--- a/packages/core-dart/lib/src/muxed/muxed_address.dart
+++ b/packages/core-dart/lib/src/muxed/muxed_address.dart
@@ -14,6 +14,9 @@ import 'encode.dart';
 ///
 /// If you need to serialize IDs for web usage, treat them as strings and
 /// apply appropriate conversion logic to maintain full 64-bit range correctness.
+///
+/// For Flutter web guidance and BigInt caveats, see
+/// [flutter-web-bigint.md](../../../../docs/guides/flutter-web-bigint.md).
 class MuxedAddress {
   static String encode({required String baseG, required BigInt id}) {
     final uint64Max = BigInt.parse('18446744073709551615');


### PR DESCRIPTION
## Summary
This PR improves Dart developer discoverability around muxed-account `BigInt` handling on Flutter web by linking the `MuxedAddress` dartdoc directly to a local guide that explains the web caveat.

The issue is that the existing API comment already warned about JavaScript precision loss, but it stopped at the inline warning text. Developers reading the generated docs did not have an obvious follow-on guide that collected the Flutter web caveats in one place.

## Root Cause
`packages/core-dart/lib/src/muxed/muxed_address.dart` described the `BigInt` / JavaScript `Number` precision risk, but there was no local markdown guide referenced from the API docs. That made the warning easy to miss or lose once a developer left the source comment.

## What Changed
I added a direct dartdoc markdown link in `MuxedAddress` pointing to a local guide at `docs/guides/flutter-web-bigint.md`.

I also added the new `flutter-web-bigint.md` guide with focused guidance for Flutter web consumers:

- why muxed IDs are risky above `2^53 - 1`
- why they should remain `BigInt`
- why web serialization should prefer strings over JS `Number`
- why precision loss matters operationally for muxed-account routing

## Validation
This is a documentation-only change. I verified the git diff is limited to the dartdoc comment in `packages/core-dart/lib/src/muxed/muxed_address.dart` and the new local guide in `docs/guides/flutter-web-bigint.md`.

Closes #66.
