### PR TITLE
feat(core-dart): add data-aware toDisplayString to RoutingResult

### DIFF
--- a/packages/core-dart/lib/src/routing/result.dart
+++ b/packages/core-dart/lib/src/routing/result.dart
@@ -49,6 +49,20 @@ class RoutingResult {
 
   BigInt? get routingIdAsBigInt =>
       routingId != null ? BigInt.parse(routingId!) : null;
+
+  String toDisplayString() {
+    switch (routingSource) {
+      case RoutingSource.muxed:
+        final id = routingId ?? 'unknown';
+        final base = destinationBaseAccount ?? 'unknown';
+        return 'Muxed routing: ID $id -> $base';
+      case RoutingSource.memo:
+        final id = routingId ?? 'unknown';
+        return 'Memo routing: ID $id';
+      case RoutingSource.none:
+        return 'No routing detected';
+    }
+  }
 }
 
 class DestinationError {

--- a/packages/core-dart/test/routing_test.dart
+++ b/packages/core-dart/test/routing_test.dart
@@ -24,4 +24,53 @@ void main() {
       );
     });
   });
+
+  group('RoutingResult.toDisplayString', () {
+    test('muxed source formats with routing ID and base account', () {
+      final result = RoutingResult(
+        routingSource: RoutingSource.muxed,
+        routingId: '12345',
+        destinationBaseAccount: 'GABC123',
+        warnings: [],
+      );
+      expect(
+        result.toDisplayString(),
+        equals('Muxed routing: ID 12345 -> GABC123'),
+      );
+    });
+
+    test('muxed source handles null values gracefully', () {
+      final result = RoutingResult(
+        routingSource: RoutingSource.muxed,
+        warnings: [],
+      );
+      expect(
+        result.toDisplayString(),
+        equals('Muxed routing: ID unknown -> unknown'),
+      );
+    });
+
+    test('memo source formats with routing ID', () {
+      final result = RoutingResult(
+        routingSource: RoutingSource.memo,
+        routingId: '99999',
+        warnings: [],
+      );
+      expect(
+        result.toDisplayString(),
+        equals('Memo routing: ID 99999'),
+      );
+    });
+
+    test('none source formats as no routing', () {
+      final result = RoutingResult(
+        routingSource: RoutingSource.none,
+        warnings: [],
+      );
+      expect(
+        result.toDisplayString(),
+        equals('No routing detected'),
+      );
+    });
+  });
 }


### PR DESCRIPTION
Closes #70

  The `RoutingResult` class now includes a data-aware `toDisplayString()` method that formats output uniquely per routing source:

  - :white_check_mark: Muxed source displays embedded uint64 routing ID and extracted base account
  - :white_check_mark: Null values handled gracefully with `'unknown'` fallback
  - :white_check_mark: Existing `RoutingSource.toDisplayString()` enum method unchanged

  ## Changes Made

  Modified `packages/core-dart/lib/src/routing/result.dart` — added `toDisplayString()` to `RoutingResult`.

  - :white_check_mark: Method switches on `routingSource` for distinct formatting per source type
    - Muxed: `"Muxed routing: ID <routingId> -> <baseAccount>"`
    - Memo: `"Memo routing: ID <routingId>"`
    - None: `"No routing detected"`
  - Null-safe fallback to `'unknown'` for missing `routingId` or `destinationBaseAccount`
  - Exhaustive switch covers all `RoutingSource` enum values

  ## Related Files Verified

  - `result.dart`: New `toDisplayString()` on `RoutingResult` class
  - `extract.dart`: Populates `routingId` and `destinationBaseAccount` correctly for muxed source
  - `routing_test.dart`: 4 new tests covering muxed (with data + nulls), memo, and none cases

  ## Conclusion

  The `RoutingResult.toDisplayString()` method clearly formats and distinguishes standard output structures for muxed-source routed IDs. The implementation is ready for UI and logging consumers.