### PR TITLE
fix(core-go): use address.EncodeStrKey to reconstruct base G in Decod…

### DIFF
--- a/packages/core-go/muxed/decode.go
+++ b/packages/core-go/muxed/decode.go
@@ -1,21 +1,35 @@
 package muxed
 
 import (
+	"encoding/binary"
+	"fmt"
 	"strconv"
 
-	"github.com/stellar/go/strkey"
+	"github.com/stellar-address-kit/core-go/address"
 )
 
+// muxedPayloadSize is the expected raw payload length after stripping the
+// version byte and checksum: 8 bytes (uint64 ID) + 32 bytes (Ed25519 key).
+const muxedPayloadSize = 40
+
 func DecodeMuxed(mAddress string) (string, string, error) {
-	muxedAccount, err := strkey.DecodeMuxedAccount(mAddress)
+	_, payload, err := address.DecodeStrKey(mAddress)
 	if err != nil {
 		return "", "", err
 	}
 
-	baseG, err := muxedAccount.AccountID()
+	if len(payload) != muxedPayloadSize {
+		return "", "", fmt.Errorf("invalid muxed address payload length: %d", len(payload))
+	}
+
+	// Muxed payload layout: [32-byte Ed25519 key][8-byte big-endian uint64 ID]
+	keyBytes := payload[:32]
+	id := binary.BigEndian.Uint64(payload[32:])
+
+	baseG, err := address.EncodeStrKey(address.VersionByteG, keyBytes)
 	if err != nil {
 		return "", "", err
 	}
 
-	return baseG, strconv.FormatUint(muxedAccount.ID(), 10), nil
+	return baseG, strconv.FormatUint(id, 10), nil
 }


### PR DESCRIPTION
Closes #79 

## fix(core-go): use `address.EncodeStrKey` to reconstruct base G in `DecodeMuxed`

### Problem

`DecodeMuxed` was delegating base G address reconstruction to the upstream
`github.com/stellar/go/strkey` library by calling `muxedAccount.AccountID()`.
This meant the StrKey encoding of the output G address was handled by an
external dependency's internals rather than the local `address.EncodeStrKey`
implementation — inconsistent with how the rest of the package handles StrKey
generation.

### Solution

Removed the dependency on `strkey.DecodeMuxedAccount` entirely. `DecodeMuxed`
now:

1. Decodes the raw M-address payload using the local `address.DecodeStrKey`
2. Slices the 40-byte payload into its components — `[32-byte Ed25519 key][8-byte big-endian uint64 ID]`
3. Re-encodes the key bytes as a G address using `address.EncodeStrKey(VersionByteG, keyBytes)`

The `github.com/stellar/go/strkey` import is no longer present in `decode.go`.

### Files Changed

- `packages/core-go/muxed/decode.go`

### Testing

All existing tests pass, including uint64 edge cases (min, max, 2^53+1 canary)
and the full spec vectors suite.

```bash
go test ./...
# ok  github.com/stellar-address-kit/core-go/address
# ok  github.com/stellar-address-kit/core-go/muxed
# ok  github.com/stellar-address-kit/core-go/routing
# ok  github.com/stellar-address-kit/core-go/spec
```