### PR TITLE
fix(core-go): replace math/big with strconv.ParseUint for bounded uint64 parsing in EncodeMuxed

### DIFF
--- a/packages/core-go/muxed/encode.go
+++ b/packages/core-go/muxed/encode.go
@@ -2,18 +2,15 @@ package muxed
 
 import (
 	"fmt"
-	"math/big"
+	"strconv"
 
 	"github.com/stellar/go/strkey"
 )
 
 func EncodeMuxed(baseG string, id string) (string, error) {
-	idInt := new(big.Int)
-	if _, ok := idInt.SetString(id, 10); !ok {
-		return "", fmt.Errorf("invalid muxed account id %q", id)
-	}
-	if idInt.Sign() < 0 || idInt.BitLen() > 64 {
-		return "", fmt.Errorf("muxed account id %q exceeds uint64", id)
+	idUint, err := strconv.ParseUint(id, 10, 64)
+	if err != nil {
+		return "", fmt.Errorf("invalid muxed account id %q: %w", id, err)
 	}
 
 	var muxedAccount strkey.MuxedAccount
@@ -21,6 +18,6 @@ func EncodeMuxed(baseG string, id string) (string, error) {
 		return "", err
 	}
 
-	muxedAccount.SetID(idInt.Uint64())
+	muxedAccount.SetID(idUint)
 	return muxedAccount.Address()
 }


### PR DESCRIPTION
Closes #83

## fix(core-go): replace `math/big` with `strconv.ParseUint` for bounded uint64 parsing in `EncodeMuxed`

### Problem

`EncodeMuxed` was using `math/big` to parse the muxed account ID string —
an arbitrary-precision integer type with no inherent upper bound. Overflow
and sign checks were then applied manually after the fact:

```go
idInt := new(big.Int)
if _, ok := idInt.SetString(id, 10); !ok { ... }
if idInt.Sign() < 0 || idInt.BitLen() > 64 { ... }
idUint, err := strconv.ParseUint(id, 10, 64)
if err != nil {
    return "", fmt.Errorf("invalid muxed account id %q: %w", id, err)
}
```
```bash
go test ./...
# ok  github.com/stellar-address-kit/core-go/address
# ok  github.com/stellar-address-kit/core-go/muxed
# ok  github.com/stellar-address-kit/core-go/routing
# ok  github.com/stellar-address-kit/core-go/spec
```