### PR TITLE
Feat/single address corruption comparision

### DIFF
--- a/examples/ts-backend/bigint-precision-auditor/README.md
+++ b/examples/ts-backend/bigint-precision-auditor/README.md
@@ -4,8 +4,14 @@ This example demonstrates how the standard JavaScript Number() constructor silen
 
 ## Quick Start
 
+```bash
 npm install
+# Run with default high-ID address
 npx tsx src/main.ts
+
+# Run with a specific muxed address
+npx tsx src/main.ts M...
+```
 
 ## Why This Matters
 

--- a/examples/ts-backend/bigint-precision-auditor/src/main.ts
+++ b/examples/ts-backend/bigint-precision-auditor/src/main.ts
@@ -8,7 +8,7 @@ import { encodeMuxed, decodeMuxed } from "stellar-address-kit";
  * stellar-address-kit's BigInt implementation preserves them.
  */
 
-const TEST_G_ADDRESS = "GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVWH4";
+const TEST_G_ADDRESS = "GAYCUYT553C5LHVE2XPW5GMEJT4BXGM7AHMJWLAPZP53KJO7EIQADRSI";
 const DEFAULT_ID = 9007199254740993n; // 2^53 + 1 (First unsafe integer)
 
 function audit(mAddress: string) {
@@ -24,20 +24,20 @@ function audit(mAddress: string) {
     const isMatch = diff === 0n;
     const matchStatus = isMatch ? "MATCH" : "CORRUPTED";
 
-    // ASCII Box-drawing output
-    console.log("+---------------------------------------------------------------+");
-    console.log("| BIGINT PRECISION AUDIT: SINGLE ADDRESS COMPARISON             |");
-    console.log("+---------------------------------------------------------------+");
-    console.log(`| Address: ${mAddress.padEnd(52)} |`);
-    console.log("+-----------------------+---------------------------------------+");
-    console.log("| PATH                  | DECODED ID VALUE                      |");
-    console.log("+-----------------------+---------------------------------------+");
-    console.log(`| Safe (BigInt)         | ${safeId.toString().padEnd(37)} |`);
-    console.log(`| Unsafe (Number)       | ${unsafeId.toString().padEnd(37)} |`);
-    console.log("+-----------------------+---------------------------------------+");
-    console.log(`| Match Status          | ${matchStatus.padEnd(37)} |`);
-    console.log(`| Numeric Difference    | ${diff.toString().padEnd(37)} |`);
-    console.log("+-----------------------+---------------------------------------+");
+    // ASCII Box-drawing output (Width: 87)
+    console.log("+-------------------------------------------------------------------------------------+");
+    console.log(`| ${"BIGINT PRECISION AUDIT: SINGLE ADDRESS COMPARISON".padEnd(83)} |`);
+    console.log("+-------------------------------------------------------------------------------------+");
+    console.log(`| ${`Address: ${mAddress}`.padEnd(83)} |`);
+    console.log("+-----------------------+-----------------------------------------------------------+");
+    console.log(`| ${"PATH".padEnd(21)} | ${"DECODED ID VALUE".padEnd(59)} |`);
+    console.log("+-----------------------+-----------------------------------------------------------+");
+    console.log(`| ${"Safe (BigInt)".padEnd(21)} | ${safeId.toString().padEnd(59)} |`);
+    console.log(`| ${"Unsafe (Number)".padEnd(21)} | ${unsafeId.toString().padEnd(59)} |`);
+    console.log("+-----------------------+-----------------------------------------------------------+");
+    console.log(`| ${"Match Status".padEnd(21)} | ${matchStatus.padEnd(59)} |`);
+    console.log(`| ${"Numeric Difference".padEnd(21)} | ${diff.toString().padEnd(59)} |`);
+    console.log("+-----------------------+-----------------------------------------------------------+");
 
     if (!isMatch) {
       console.log("\n[!] ALERT: Precision loss detected!");
@@ -57,8 +57,9 @@ const arg = process.argv[2];
 let targetAddress = arg;
 
 if (!arg) {
-  console.log(`No address provided. Auditing default ID: ${DEFAULT_ID}`);
   targetAddress = encodeMuxed(TEST_G_ADDRESS, DEFAULT_ID);
+  console.log(`No address provided. Auditing default ID: ${DEFAULT_ID}`);
+  console.log(`Encoded M-address: ${targetAddress}`);
 }
 
 audit(targetAddress);

--- a/examples/ts-backend/bigint-precision-auditor/src/main.ts
+++ b/examples/ts-backend/bigint-precision-auditor/src/main.ts
@@ -1,47 +1,64 @@
 import { encodeMuxed, decodeMuxed } from "stellar-address-kit";
 
 /**
- * BigInt Precision Auditor
- * This tool demonstrates how JavaScript's Number type silently corrupts
- * Stellar muxed account IDs (uint64) and how stellar-address-kit solves this.
+ * BigInt Precision Auditor - Single Address Comparison
+ * 
+ * This tool demonstrates how JavaScript's Number type (float64) silently
+ * corrupts 64-bit integer IDs used in Stellar muxed addresses, and how
+ * stellar-address-kit's BigInt implementation preserves them.
  */
 
 const TEST_G_ADDRESS = "GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVWH4";
+const DEFAULT_ID = 9007199254740993n; // 2^53 + 1 (First unsafe integer)
 
-// Test these IDs: [0, 1, 2^53-1, 2^53, 2^53+1, 2^64-1]
-const ids = [
-  0n,
-  1n,
-  (2n ** 53n) - 1n, // 2^53-1: MAX_SAFE_INTEGER
-  2n ** 53n,        // 2^53: Still representable
-  (2n ** 53n) + 1n, // 2^53+1: First unrepresentable uint64
-  18446744073709551615n // 2^64-1: MAX_UINT64
-];
+function audit(mAddress: string) {
+  try {
+    // Safe path: decode via stellar-address-kit, keep as BigInt
+    const { id: safeId } = decodeMuxed(mAddress);
+    
+    // Unsafe path: extract muxed ID, convert to Number()
+    const unsafeId = Number(safeId);
+    
+    // Comparison logic
+    const diff = safeId - BigInt(unsafeId);
+    const isMatch = diff === 0n;
+    const matchStatus = isMatch ? "MATCH" : "CORRUPTED";
 
-console.log("BigInt Precision Audit: Batch ID Range Corruption Sweep\n");
+    // ASCII Box-drawing output
+    console.log("+---------------------------------------------------------------+");
+    console.log("| BIGINT PRECISION AUDIT: SINGLE ADDRESS COMPARISON             |");
+    console.log("+---------------------------------------------------------------+");
+    console.log(`| Address: ${mAddress.padEnd(52)} |`);
+    console.log("+-----------------------+---------------------------------------+");
+    console.log("| PATH                  | DECODED ID VALUE                      |");
+    console.log("+-----------------------+---------------------------------------+");
+    console.log(`| Safe (BigInt)         | ${safeId.toString().padEnd(37)} |`);
+    console.log(`| Unsafe (Number)       | ${unsafeId.toString().padEnd(37)} |`);
+    console.log("+-----------------------+---------------------------------------+");
+    console.log(`| Match Status          | ${matchStatus.padEnd(37)} |`);
+    console.log(`| Numeric Difference    | ${diff.toString().padEnd(37)} |`);
+    console.log("+-----------------------+---------------------------------------+");
 
-let corruptedCount = 0;
-
-for (const id of ids) {
-  // Encode muxed address
-  const mAddress = encodeMuxed(TEST_G_ADDRESS, id);
-  
-  // Path A: BigInt path (Library Default)
-  const decodedBigInt = decodeMuxed(mAddress).id;
-  
-  // Path B: Number path (Lossy coercion)
-  const decodedNumber = Number(decodedBigInt);
-  
-  // Audit comparison
-  const isMatch = BigInt(decodedNumber) === decodedBigInt;
-  if (!isMatch) {
-    corruptedCount++;
+    if (!isMatch) {
+      console.log("\n[!] ALERT: Precision loss detected!");
+      console.log(`    The ID ${safeId} is too large for Number().`);
+      console.log(`    It has been corrupted to ${unsafeId}.`);
+    } else {
+      console.log("\n[OK] No precision loss detected for this ID.");
+    }
+  } catch (error) {
+    console.error(`\n[!] Error: ${error instanceof Error ? error.message : String(error)}`);
+    process.exit(1);
   }
-  
-  const status = isMatch ? "✓ Match" : "✗ CORRUPTED";
-  
-  // Output format: ID Number: BigInt: ✓ Match or ✗ CORRUPTED.
-  console.log(`ID ${id} Number: ${decodedNumber} BigInt: ${decodedBigInt} ${status}`);
 }
 
-console.log(`\n${corruptedCount} of ${ids.length} IDs corrupted by Number()`);
+// Accept one CLI argument: a muxed M-address.
+const arg = process.argv[2];
+let targetAddress = arg;
+
+if (!arg) {
+  console.log(`No address provided. Auditing default ID: ${DEFAULT_ID}`);
+  targetAddress = encodeMuxed(TEST_G_ADDRESS, DEFAULT_ID);
+}
+
+audit(targetAddress);


### PR DESCRIPTION
## What this PR does

Adds a CLI tool to compare precision loss when decoding a single muxed address using JavaScript `Number` vs `BigInt`.

Closes #213

---

## Approach

- Accepts a muxed M-address as input (defaults to an address with ID `2^53 + 1`)
- Decodes the ID using:
  - `Number` (unsafe path)
  - `stellar-address-kit` (safe BigInt path)
- Prints a side-by-side comparison with match status and numeric difference in an ASCII table

---

## Result

Clearly demonstrates precision loss when using `Number` for muxed IDs above `2^53 - 1`, while `BigInt` preserves the correct value.