### PR TITLE
Implement Routing Analysis for Exchange Withdrawal Validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <h1 align="center">Stellar Address Kit</h1>
 
 <p align="center">
-  <b>The deposit routing spec for Stellar, implemented in TypeScript, Go, and Dart.</b>
+  <b>The deposit routing spec for Stellar, implemented in TypeScript, Go, and Dart. All 3 packages are live</b>
 </p>
 
 <p align="center">

--- a/examples/ts-backend/exchange-withdrawal-validator/package.json
+++ b/examples/ts-backend/exchange-withdrawal-validator/package.json
@@ -6,6 +6,9 @@
     "express": "^4.18.3",
     "stellar-address-kit": "^1.0.1"
   },
+  "scripts": {
+    "start": "tsx src/server.ts"
+  },
   "devDependencies": {
     "@types/express": "^4.17.21",
     "tsx": "^4.7.1",

--- a/examples/ts-backend/exchange-withdrawal-validator/src/public/index.html
+++ b/examples/ts-backend/exchange-withdrawal-validator/src/public/index.html
@@ -5,12 +5,20 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Exchange Withdrawal Validator</title>
     <style>
-        body { font-family: sans-serif; max-width: 600px; margin: 40px auto; padding: 20px; }
+        body { font-family: sans-serif; max-width: 600px; margin: 40px auto; padding: 20px; line-height: 1.6; }
         .form-group { margin-bottom: 15px; }
-        label { display: block; margin-bottom: 5px; }
-        input, select { width: 100%; padding: 8px; box-sizing: border-box; }
-        button { padding: 10px 20px; cursor: pointer; }
-        #result { margin-top: 20px; padding: 15px; border: 1px solid #ddd; display: none; }
+        label { display: block; margin-bottom: 5px; font-weight: bold; }
+        input, select { width: 100%; padding: 8px; box-sizing: border-box; border: 1px solid #ccc; border-radius: 4px; }
+        button { padding: 10px 20px; cursor: pointer; background-color: #007bff; color: white; border: none; border-radius: 4px; }
+        button:hover { background-color: #0056b3; }
+        #result { margin-top: 20px; padding: 20px; border: 1px solid #ddd; border-radius: 8px; display: none; background-color: #f9f9f9; }
+        .result-item { margin-bottom: 10px; }
+        .result-label { font-weight: bold; color: #555; }
+        .warning { padding: 8px 12px; margin-top: 5px; border-radius: 4px; border-left: 4px solid; }
+        .warning-info { background-color: #e7f3ff; border-left-color: #007bff; color: #004085; }
+        .warning-warn { background-color: #fff3cd; border-left-color: #ffc107; color: #856404; }
+        .warning-error { background-color: #f8d7da; border-left-color: #dc3545; color: #721c24; }
+        .banner-none { background-color: #fff3cd; border: 1px solid #ffeeba; color: #856404; padding: 15px; border-radius: 4px; margin-top: 20px; text-align: center; font-weight: bold; }
     </style>
 </head>
 <body>
@@ -37,9 +45,10 @@
         <input type="text" id="memoValue" placeholder="Enter memo value">
     </div>
 
-    <button id="submit">Validate Withdrawal</button>
+    <button id="submit">Analyze Routing</button>
 
     <div id="result"></div>
+    <div id="banner-container"></div>
 
     <script>
         const submitBtn = document.getElementById('submit');
@@ -47,21 +56,93 @@
         const memoTypeSelect = document.getElementById('memoType');
         const memoValueInput = document.getElementById('memoValue');
         const resultDiv = document.getElementById('result');
+        const bannerContainer = document.getElementById('banner-container');
 
         submitBtn.addEventListener('click', async () => {
             const data = {
-                address: addressInput.value,
+                address: addressInput.value.trim(),
                 memoType: memoTypeSelect.value,
-                memoValue: memoValueInput.value
+                memoValue: memoValueInput.value.trim()
             };
 
-            // Logic will be implemented later
-            resultDiv.style.display = 'block';
-            resultDiv.textContent = 'Submission received (placeholder)';
+            if (!data.address) {
+                alert('Please enter a Stellar address.');
+                return;
+            }
+
+            try {
+                const response = await fetch('/api/analyze', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(data)
+                });
+
+                const result = await response.json();
+
+                if (!response.ok) {
+                    resultDiv.style.display = 'block';
+                    resultDiv.innerHTML = `<div class="warning warning-error">${result.error || 'An error occurred'}</div>`;
+                    bannerContainer.innerHTML = '';
+                    return;
+                }
+
+                displayResult(result);
+            } catch (error) {
+                resultDiv.style.display = 'block';
+                resultDiv.innerHTML = `<div class="warning warning-error">Failed to connect to the server.</div>`;
+                bannerContainer.innerHTML = '';
+            }
         });
 
+        function displayResult(result) {
+            resultDiv.style.display = 'block';
+            bannerContainer.innerHTML = '';
+
+            let html = `
+                <div class="result-item">
+                    <span class="result-label">Routing Source:</span> 
+                    <code>${result.routingSource}</code>
+                </div>
+                <div class="result-item">
+                    <span class="result-label">Routing ID:</span> 
+                    <code>${result.routingId || 'None'}</code>
+                </div>
+                <div class="result-item">
+                    <span class="result-label">Destination Base Account:</span> 
+                    <code>${result.destinationBaseAccount || 'None'}</code>
+                </div>
+            `;
+
+            if (result.warnings && result.warnings.length > 0) {
+                html += '<div class="result-label">Warnings:</div>';
+                result.warnings.forEach(w => {
+                    const severityClass = `warning-${w.severity}`;
+                    html += `<div class="warning ${severityClass}">${w.message}</div>`;
+                });
+            }
+
+            resultDiv.innerHTML = html;
+
+            if (result.routingSource === 'none') {
+                bannerContainer.innerHTML = `
+                    <div class="banner-none">
+                        No routing information detected. This withdrawal may not be attributable to a specific user.
+                    </div>
+                `;
+            }
+        }
+
         addressInput.addEventListener('input', () => {
-            // Logic for disabling memo for M-addresses will be implemented later
+            const val = addressInput.value.trim();
+            if (val.startsWith('M')) {
+                memoTypeSelect.value = 'none';
+                memoTypeSelect.disabled = true;
+                memoValueInput.value = '';
+                memoValueInput.disabled = true;
+            } else {
+                memoTypeSelect.disabled = false;
+                memoValueInput.disabled = false;
+            }
         });
     </script>
 </body>

--- a/examples/ts-backend/exchange-withdrawal-validator/src/server.ts
+++ b/examples/ts-backend/exchange-withdrawal-validator/src/server.ts
@@ -2,6 +2,8 @@ import express from 'express';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
+import { extractRouting, RoutingInput } from 'stellar-address-kit';
+
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
@@ -17,8 +19,28 @@ app.post('/api/validate', (req, res) => {
 });
 
 app.post('/api/analyze', (req, res) => {
-  // Placeholder for address analysis
-  res.json({});
+  const { address, memoType, memoValue } = req.body;
+
+  try {
+    const input: RoutingInput = {
+      destination: address,
+      memoType: memoType === 'none' ? 'none' : memoType,
+      memoValue: memoValue || null,
+      sourceAccount: null,
+    };
+
+    const result = extractRouting(input);
+    
+    // Convert BigInt to string for JSON serialization
+    const serializedResult = {
+      ...result,
+      routingId: result.routingId?.toString() || null,
+    };
+
+    res.json(serializedResult);
+  } catch (error: any) {
+    res.status(400).json({ error: error.message });
+  }
 });
 
 app.listen(port, () => {


### PR DESCRIPTION
## Overview
This PR adds a "Routing Analysis" feature to the Exchange Withdrawal Validator example. It enables exchanges to analyze a Stellar destination (Address + Memo) before processing a withdrawal to ensure it is correctly attributable to a user and to detect potential routing issues.

## Changes

### Backend (`examples/ts-backend/exchange-withdrawal-validator`)
- **New Endpoint**: Added `POST /api/analyze` which accepts `{ address, memoType, memoValue }`.
- **Logic**: Integrates `extractRouting` from `stellar-address-kit` to parse the destination and determine the routing source (Muxed, Memo, or None).
- **Serialization**: Handled `BigInt` serialization for `routingId` to ensure compatible JSON responses.
- **Error Handling**: Added robust error handling for invalid address formats or structural routing errors.

### Frontend (`src/public/index.html`)
- **UI Enhancement**: Added a results panel below the form to display:
    - **Routing Source**: (e.g., `muxed`, `memo`, `none`).
    - **Routing ID**: The extracted destination ID.
    - **Warnings**: List of warnings with color-coded severity (Blue for Info, Amber for Warn, Red for Error).
- **Safety Banner**: Implemented an amber banner that triggers when `routingSource` is `none`, alerting the operator that the withdrawal may not be attributable to a specific user.
- **Interactive UX**: Added logic to automatically disable and clear memo fields when a Muxed (M-) address is entered, preventing conflicting routing information.

### Tooling
- **Start Script**: Added a `start` script to `package.json` for easier local development using `tsx`.

## How to Test
1. Navigate to `examples/ts-backend/exchange-withdrawal-validator`.
2. Run `npm install` and `npm start`.
3. Open `http://localhost:3000` in your browser.
4. **Test Cases**:
    - **G-address + Memo ID**: Should show routing via `memo` with the correct ID.
    - **M-address**: Should show routing via `muxed` and disable the memo fields.
    - **G-address (No Memo)**: Should show routing source `none` and display the amber warning banner.
    - **Invalid Address**: Should display a red error warning.

## Related Issue
Closes #219 