### PR TITLE
feat: add python-compliance-logger with terminal summary report (#256)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /node_modules
+__pycache__/

--- a/examples/python-compliance-logger/README.md
+++ b/examples/python-compliance-logger/README.md
@@ -1,0 +1,89 @@
+# python-compliance-logger
+
+A Python CLI tool that reads a CSV of Stellar deposit addresses, classifies
+each one by address type (G / M / C) and risk label, writes an annotated
+output CSV, and prints a formatted summary table to `stderr`.
+
+Implements [issue #256](https://github.com/Boxkit-Labs/stellar-address-kit/issues/256).
+
+## Requirements
+
+Python 3.10+. No third-party dependencies.
+
+## Usage
+
+```bash
+python3 main.py <input.csv> <output.csv>
+```
+
+### Input CSV
+
+| Column | Required | Description |
+|---|---|---|
+| `address` | yes | Stellar address (G-, M-, or C-address) |
+| `memo_type` | no | `ID`, `TEXT`, `HASH`, or `RETURN` |
+| `memo_value` | no | The memo value |
+
+Example `deposits.csv`:
+
+```csv
+address,memo_type,memo_value
+GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLT7AV7Y6S33Z6S3CHBVQQNHNMGDPZAQ6BXQFN33,ID,12345
+MA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLT7AV7Y6S33Z6S3CHBAAAAAAAAAAAAABQD,,
+CA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLT7AV7Y6S33Z6S3CHBQQ,,
+GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLT7AV7Y6S33Z6S3CHBVQQNHNMGDPZAQ6BXQFN33,TEXT,99
+```
+
+### Output CSV
+
+The output file contains all original columns plus:
+
+| Column | Description |
+|---|---|
+| `address_type` | `G`, `M`, or `C` |
+| `risk_label` | Classification result (see table below) |
+| `notes` | Human-readable explanation |
+
+### Risk Labels
+
+| Label | Meaning |
+|---|---|
+| `OK` | Routable, no issues |
+| `WARN_REDUNDANT_MEMO` | M-address with an external memo (memo is ignored) |
+| `WARN_MEMO_TYPE_MISMATCH` | Numeric `MEMO_TEXT` that should have been `MEMO_ID` |
+| `NON_ROUTABLE_MEMO` | Memo present but cannot yield a numeric routing ID |
+| `MISSING_MEMO` | G-address with no memo — deposit cannot be routed |
+| `INVALID_DESTINATION` | C-address — cannot receive deposits |
+
+### Terminal Summary
+
+After writing the CSV, the tool prints a summary to `stderr`:
+
+```
++--------------------------------------------------+
+|                COMPLIANCE SUMMARY                |
++--------------------------------------------------+
+| Total transactions:          4                    |
++--------------------------------------------------+
+| ADDRESS TYPE                 COUNT                |
++--------------------------------------------------+
+| C                            1                    |
+| G                            2                    |
+| M                            1                    |
++--------------------------------------------------+
+| RISK LABEL                   COUNT                |
++--------------------------------------------------+
+| INVALID_DESTINATION          1                    |
+| OK                           2                    |
+| WARN_MEMO_TYPE_MISMATCH      1                    |
++--------------------------------------------------+
+```
+
+## Project Structure
+
+```
+python-compliance-logger/
+├── main.py          # Entry point
+└── src/
+    └── reporter.py  # print_summary(rows) terminal report
+```

--- a/examples/python-compliance-logger/main.py
+++ b/examples/python-compliance-logger/main.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""
+python-compliance-logger
+Reads a CSV of Stellar addresses, classifies each one, writes an annotated
+output CSV, then prints a formatted summary to stderr.
+
+Input CSV columns : address, memo_type (optional), memo_value (optional)
+Output CSV columns: address, memo_type, memo_value, address_type, risk_label, notes
+"""
+import csv
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "src"))
+from reporter import print_summary
+
+
+def classify(address: str, memo_type: str, memo_value: str) -> dict:
+    address = address.strip()
+    memo_type = memo_type.strip().upper()
+    memo_value = memo_value.strip()
+
+    if address.startswith("C"):
+        return {
+            "address_type": "C",
+            "risk_label": "INVALID_DESTINATION",
+            "notes": "Contract addresses cannot receive memo-based deposits.",
+        }
+
+    if address.startswith("M"):
+        addr_type = "M"
+        if memo_type and memo_value:
+            return {
+                "address_type": addr_type,
+                "risk_label": "WARN_REDUNDANT_MEMO",
+                "notes": "M-address already encodes a routing ID; external memo ignored.",
+            }
+        return {"address_type": addr_type, "risk_label": "OK", "notes": ""}
+
+    if address.startswith("G"):
+        addr_type = "G"
+        if memo_type == "ID" and memo_value:
+            return {"address_type": addr_type, "risk_label": "OK", "notes": ""}
+        if memo_type == "TEXT" and memo_value.isdigit():
+            return {
+                "address_type": addr_type,
+                "risk_label": "WARN_MEMO_TYPE_MISMATCH",
+                "notes": "Numeric MEMO_TEXT should be MEMO_ID.",
+            }
+        if memo_type in ("TEXT", "HASH", "RETURN") and memo_value:
+            return {
+                "address_type": addr_type,
+                "risk_label": "NON_ROUTABLE_MEMO",
+                "notes": "Cannot extract a numeric routing ID from this memo.",
+            }
+        return {
+            "address_type": addr_type,
+            "risk_label": "MISSING_MEMO",
+            "notes": "G-address deposit has no routing memo.",
+        }
+
+    return {"address_type": "UNKNOWN", "risk_label": "UNKNOWN", "notes": "Unrecognised address prefix."}
+
+
+def process(input_path: str, output_path: str) -> list[dict]:
+    rows: list[dict] = []
+    with open(input_path, newline="") as f_in, open(output_path, "w", newline="") as f_out:
+        reader = csv.DictReader(f_in)
+        fieldnames = ["address", "memo_type", "memo_value", "address_type", "risk_label", "notes"]
+        writer = csv.DictWriter(f_out, fieldnames=fieldnames)
+        writer.writeheader()
+
+        for record in reader:
+            address = record.get("address", "")
+            memo_type = record.get("memo_type", "")
+            memo_value = record.get("memo_value", "")
+            result = classify(address, memo_type, memo_value)
+            row = {
+                "address": address,
+                "memo_type": memo_type,
+                "memo_value": memo_value,
+                **result,
+            }
+            writer.writerow(row)
+            rows.append(row)
+
+    return rows
+
+
+def main() -> None:
+    if len(sys.argv) != 3:
+        print(f"Usage: {sys.argv[0]} <input.csv> <output.csv>", file=sys.stderr)
+        sys.exit(1)
+
+    input_path, output_path = sys.argv[1], sys.argv[2]
+    rows = process(input_path, output_path)
+    print(f"Wrote {len(rows)} rows to {output_path}", file=sys.stderr)
+    print_summary(rows)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/python-compliance-logger/src/reporter.py
+++ b/examples/python-compliance-logger/src/reporter.py
@@ -1,0 +1,37 @@
+import sys
+from collections import Counter
+
+
+def print_summary(rows: list[dict]) -> None:
+    total = len(rows)
+    by_type = Counter(r.get("address_type", "UNKNOWN") for r in rows)
+    by_risk = Counter(r.get("risk_label", "UNKNOWN") for r in rows)
+
+    def _row(label: str, value) -> str:
+        return f"| {label:<28} {str(value):<20} |"
+
+    width = 52
+    border = "+" + "-" * (width - 2) + "+"
+    header = "| {:^{w}} |".format("COMPLIANCE SUMMARY", w=width - 4)
+
+    lines = [
+        border,
+        header,
+        border,
+        _row("Total transactions:", total),
+        border,
+        _row("ADDRESS TYPE", "COUNT"),
+        border,
+    ]
+    for addr_type, count in sorted(by_type.items()):
+        lines.append(_row(addr_type, count))
+    lines += [
+        border,
+        _row("RISK LABEL", "COUNT"),
+        border,
+    ]
+    for risk, count in sorted(by_risk.items()):
+        lines.append(_row(risk, count))
+    lines.append(border)
+
+    print("\n".join(lines), file=sys.stderr)


### PR DESCRIPTION
 add python-compliance-logger terminal summary report (#256)
  
  - Add src/reporter.py with print_summary(rows) printing ASCII box table to stderr
  - Add main.py to classify addresses (G/M/C), write annotated CSV, then call print_summary
  - Add README.md with usage, risk label reference, and sample output

closes #256
