### PR TITLE
feat(dart): expose extractRoutingSync and async extractRouting APIs

### DIFF
--- a/packages/core-dart/example/main.dart
+++ b/packages/core-dart/example/main.dart
@@ -1,6 +1,6 @@
 import 'package:stellar_address_kit/stellar_address_kit.dart';
 
-void main() {
+void main() async {
   // 1. Detect and Validate address types
   const gAddress = 'GA7QYNF7SOWQ3GLR2B6RS22TBGZAOR6KLYH4PA5ZAM73A3H4K2HZZSQU';
   
@@ -21,9 +21,9 @@ void main() {
   final decoded = MuxedAddress.decode(mAddress);
   print('Decoded ID: ${decoded.id}'); // 12345
 
-  // 5. Extract routing information from an incoming payment
+  // 5. Extract routing information from an incoming payment (async API)
   // This is used to reconcile deposits in a pooled account.
-  final result = extractRouting(RoutingInput(
+  final result = await extractRouting(RoutingInput(
     destination: mAddress,
     memoType: 'none',
     memoValue: null,
@@ -31,4 +31,14 @@ void main() {
 
   print('Routing ID: ${result.id}'); // 12345
   print('Routing Source: ${result.source}'); // RoutingSource.muxed
+
+  // 6. Synchronous variant for pure string parsing
+  final syncResult = extractRoutingSync(RoutingInput(
+    destination: mAddress,
+    memoType: 'none',
+    memoValue: null,
+  ));
+
+  print('Sync Routing ID: ${syncResult.id}'); // 12345
+  print('Sync Routing Source: ${syncResult.source}'); // RoutingSource.muxed
 }

--- a/packages/core-dart/lib/src/routing/extract.dart
+++ b/packages/core-dart/lib/src/routing/extract.dart
@@ -7,7 +7,11 @@ import 'memo.dart';
 /// Extracts deposit routing information from a Stellar payment input.
 /// Following the standard priority policy, M-address identifiers take
 /// precedence over any provided memo.
-RoutingResult extractRouting(RoutingInput input) {
+///
+/// This is the synchronous variant for pure string parsing.
+/// For future compatibility with async network checks (Federation, SEP-0029),
+/// use [extractRouting] instead.
+RoutingResult extractRoutingSync(RoutingInput input) {
   final trimmed = input.destination.trim();
   if (trimmed.isEmpty) {
     throw const ExtractRoutingException('Invalid input: destination must be a non-empty string.');
@@ -214,5 +218,14 @@ RoutingResult extractRouting(RoutingInput input) {
     source: routingSource,
     warnings: warnings,
   );
+}
+
+/// Extracts deposit routing information with support for future
+/// async network checks (Federation, SEP-0029).
+///
+/// Currently delegates to [extractRoutingSync]; when async capabilities
+/// are added this function will perform the additional checks.
+Future<RoutingResult> extractRouting(RoutingInput input) async {
+  return extractRoutingSync(input);
 }
 

--- a/packages/core-dart/test/extract_routing_test.dart
+++ b/packages/core-dart/test/extract_routing_test.dart
@@ -6,9 +6,9 @@ void main() {
   const muxedAddress =
       'MAYCUYT553C5LHVE2XPW5GMEJT4BXGM7AHMJWLAPZP53KJO7EIQACABAAAAAAAAAAEVIG';
 
-  group('extractRouting', () {
+  group('extractRoutingSync', () {
     test('decodes muxed routing when no external memo is present', () {
-      final result = extractRouting(
+      final result = extractRoutingSync(
         RoutingInput(destination: muxedAddress, memoType: 'none'),
       );
 
@@ -20,7 +20,7 @@ void main() {
     });
 
     test('prefers external memo over muxed routing and emits memo-ignored warning', () {
-      final result = extractRouting(
+      final result = extractRoutingSync(
         RoutingInput(
           destination: muxedAddress,
           memoType: 'id',
@@ -37,7 +37,7 @@ void main() {
     });
 
     test('keeps muxed decode valid when external memo is unroutable', () {
-      final result = extractRouting(
+      final result = extractRoutingSync(
         RoutingInput(
           destination: muxedAddress,
           memoType: 'text',
@@ -56,7 +56,7 @@ void main() {
     });
 
     test('preserves existing non-muxed memo routing behavior', () {
-      final result = extractRouting(
+      final result = extractRoutingSync(
         RoutingInput(
           destination: baseG,
           memoType: 'id',
@@ -74,13 +74,92 @@ void main() {
     test('throws ExtractRoutingException for C-addresses', () {
       const cAddress = 'CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC';
       expect(
-        () => extractRouting(RoutingInput(destination: cAddress, memoType: 'none')),
+        () => extractRoutingSync(RoutingInput(destination: cAddress, memoType: 'none')),
         throwsA(isA<ExtractRoutingException>()),
       );
     });
 
     test('throws ExtractRoutingException for empty destination', () {
       expect(
+        () => extractRoutingSync(RoutingInput(destination: '', memoType: 'none')),
+        throwsA(isA<ExtractRoutingException>()),
+      );
+    });
+  });
+
+  group('extractRouting (async)', () {
+    test('decodes muxed routing when no external memo is present', () async {
+      await expectLater(
+        extractRouting(RoutingInput(destination: muxedAddress, memoType: 'none')),
+        completion(predicate((RoutingResult result) =>
+            result.destinationBaseAccount == baseG &&
+            result.id == BigInt.parse('9007199254740993') &&
+            result.source == RoutingSource.muxed &&
+            result.warnings.isEmpty &&
+            result.destinationError == null)),
+      );
+    });
+
+    test('prefers external memo over muxed routing and emits memo-ignored warning', () async {
+      await expectLater(
+        extractRouting(RoutingInput(
+          destination: muxedAddress,
+          memoType: 'id',
+          memoValue: '42',
+        )),
+        completion(predicate((RoutingResult result) =>
+            result.destinationBaseAccount == baseG &&
+            result.id == BigInt.from(42) &&
+            result.source == RoutingSource.memo &&
+            result.destinationError == null &&
+            result.warnings.length == 1 &&
+            result.warnings.first.code == 'memo-ignored')),
+      );
+    });
+
+    test('keeps muxed decode valid when external memo is unroutable', () async {
+      await expectLater(
+        extractRouting(RoutingInput(
+          destination: muxedAddress,
+          memoType: 'text',
+          memoValue: 'not-a-routing-id',
+        )),
+        completion(predicate((RoutingResult result) =>
+            result.destinationBaseAccount == baseG &&
+            result.id == null &&
+            result.source == RoutingSource.none &&
+            result.destinationError == null &&
+            result.warnings.map((w) => w.code).toList() ==
+                ['memo-ignored', 'MEMO_TEXT_UNROUTABLE'])),
+      );
+    });
+
+    test('preserves existing non-muxed memo routing behavior', () async {
+      await expectLater(
+        extractRouting(RoutingInput(
+          destination: baseG,
+          memoType: 'id',
+          memoValue: '100',
+        )),
+        completion(predicate((RoutingResult result) =>
+            result.destinationBaseAccount == baseG &&
+            result.id == BigInt.from(100) &&
+            result.source == RoutingSource.memo &&
+            result.warnings.isEmpty &&
+            result.destinationError == null)),
+      );
+    });
+
+    test('propagates ExtractRoutingException for C-addresses as a Future error', () async {
+      const cAddress = 'CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC';
+      await expectLater(
+        () => extractRouting(RoutingInput(destination: cAddress, memoType: 'none')),
+        throwsA(isA<ExtractRoutingException>()),
+      );
+    });
+
+    test('propagates ExtractRoutingException for empty destination as a Future error', () async {
+      await expectLater(
         () => extractRouting(RoutingInput(destination: '', memoType: 'none')),
         throwsA(isA<ExtractRoutingException>()),
       );

--- a/packages/core-dart/test/spec_runner_test.dart
+++ b/packages/core-dart/test/spec_runner_test.dart
@@ -46,7 +46,7 @@ void main() {
           caseData['description']?.toString() ?? 'Unnamed';
       final String module = caseData['module']?.toString() ?? '';
 
-      test('$module: $description', () {
+      test('$module: $description', () async {
         final input = caseData['input'] as Map<String, dynamic>;
         final expected = caseData['expected'] as Map<String, dynamic>;
 
@@ -95,7 +95,7 @@ void main() {
             );
 
             try {
-              final result = extractRouting(routingInput);
+              final result = await extractRouting(routingInput);
 
               expect(result.destinationBaseAccount,
                   normalizeExpectedBaseAccount(expected['destinationBaseAccount']));


### PR DESCRIPTION
## Summary

Closes #272

Expose both synchronous and asynchronous routing extraction APIs for the Dart package while preserving the existing parsing behavior.

## Changes

* Renamed `extractRouting` to `extractRoutingSync` for synchronous routing extraction.
* Added a future-compatible asynchronous `extractRouting` wrapper that currently delegates to `extractRoutingSync`.
* Added isolated unit tests covering both synchronous and asynchronous execution paths.
* Updated the spec runner to exercise the asynchronous API.
* Updated the Dart example to demonstrate both APIs.

## Notes

The parsing implementation is unchanged. The new asynchronous API provides a forward-compatible entry point for future network-backed features such as Federation and SEP-0029 checks while allowing existing synchronous consumers to continue using `extractRoutingSync`.
