### PR TITLE
feat(prism-core): add differential testing against stellar-strkey, fix M-address payload bug

### DIFF
--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -1,0 +1,43 @@
+name: ci-rust
+
+on:
+  pull_request:
+    paths:
+      - "examples/prism-core/**"
+      - "examples/rust-address-fuzzer/**"
+      - "spec/vectors.json"
+      - ".github/workflows/ci-rust.yml"
+
+concurrency:
+  group: ci-rust-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test:
+    name: Rust tests & build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+          cache: false
+
+      - name: Test prism-core (lib)
+        run: cargo test -p prism-core
+
+      - name: Test rust-address-fuzzer
+        run: cargo test -p rust-address-fuzzer
+
+      - name: Build prism-diff binary
+        run: cargo build -p prism-core --features diff --bin prism-diff
+
+      - name: Run prism-diff smoke test (1k random inputs)
+        run: cargo run -p prism-core --features diff --bin prism-diff -- --random 1000 --seed 42

--- a/examples/prism-core/Cargo.toml
+++ b/examples/prism-core/Cargo.toml
@@ -2,9 +2,24 @@
 name = "prism-core"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.87.0"
 description = "Rust implementation of the stellar-address-kit Stellar address parser"
 license = "MIT"
 
 [lib]
 name = "prism_core"
 path = "src/lib.rs"
+
+[[bin]]
+name = "prism-diff"
+path = "src/diff.rs"
+required-features = ["diff"]
+
+[features]
+default = []
+diff = ["dep:stellar-strkey", "dep:clap", "dep:rand"]
+
+[dependencies]
+stellar-strkey = { version = "0.0.18", optional = true }
+clap = { version = "4", features = ["derive"], optional = true }
+rand = { version = "0.8", optional = true }

--- a/examples/prism-core/src/address.rs
+++ b/examples/prism-core/src/address.rs
@@ -134,16 +134,25 @@ pub fn parse(input: &str) -> Result<Address, ParseError> {
         if payload.len() < 41 {
             return Err(ParseError::InvalidMuxedPayload);
         }
-        let id_bytes: [u8; 8] = payload[1..9].try_into().map_err(|_| ParseError::InvalidMuxedPayload)?;
+        // SEP-0023 MuxedAccount payload layout:
+        //   version_byte || ed25519_pubkey(32) || muxed_id(8, big-endian)
+        let base_g = encode_g_address(&payload[1..33])?;
+        let id_bytes: [u8; 8] = payload[33..41]
+            .try_into()
+            .map_err(|_| ParseError::InvalidMuxedPayload)?;
         let muxed_id = u64::from_be_bytes(id_bytes);
-        let base_g = encode_g_address(&payload[9..41])?;
-        return Ok(Address { kind, raw: upper, base_g: Some(base_g), muxed_id: Some(muxed_id) });
+        return Ok(Address {
+            kind,
+            raw: upper,
+            base_g: Some(base_g),
+            muxed_id: Some(muxed_id),
+        });
     }
 
     Ok(Address { kind, raw: upper, base_g: None, muxed_id: None })
 }
 
-fn encode_g_address(key: &[u8]) -> Result<String, ParseError> {
+pub fn encode_g_address(key: &[u8]) -> Result<String, ParseError> {
     if key.len() != 32 {
         return Err(ParseError::InvalidMuxedPayload);
     }
@@ -195,16 +204,18 @@ mod tests {
 
     #[test]
     fn invalid_base32_character() {
+        // 56-char G-prefix string with a '0' at position 1.
         assert!(matches!(
-            parse("G0HJJJKMOKYE4RVPZEWZTKH5FVI4PA3VL7GK2LFNUBSGBV3PR5T4Q"),
+            parse("G0HJJJKMOKYE4RVPZEWZTKH5FVI4PA3VL7GK2LFNUBSGBV3PR5T4QABC"),
             Err(ParseError::InvalidBase32 { .. })
         ));
     }
 
     #[test]
     fn valid_g_address_parses() {
-        let result = parse("GAHJJJKMOKYE4RVPZEWZTKH5FVI4PA3VL7GK2LFNUBSGBV3PR5T4Q");
-        assert!(result.is_ok());
+        // Verified against the stellar-strkey reference decoder (0.0.18).
+        let result = parse("GAYCUYT553C5LHVE2XPW5GMEJT4BXGM7AHMJWLAPZP53KJO7EIQADRSI");
+        assert!(result.is_ok(), "unexpected error: {result:?}");
         let parsed = result.unwrap();
         assert_eq!(parsed.kind(), AddressKind::G);
         assert_eq!(parsed.base_g(), None);

--- a/examples/prism-core/src/diff.rs
+++ b/examples/prism-core/src/diff.rs
@@ -1,0 +1,344 @@
+//! Differential testing binary that compares prism-core's address parser against
+//! the `stellar-strkey` reference decoder. Any divergence in accept/reject verdicts
+//! or decoded fields is reported as a finding, since STA claims cross-implementation
+//! correctness.
+//!
+//! # Usage
+//! ```text
+//! cargo run --features diff --bin prism-diff -- --random 10000
+//! cargo run --features diff --bin prism-diff -- --corpus path/to/inputs.txt
+//! cargo run --features diff --bin prism-diff -- --stdin
+//! ```
+
+use std::io::{self, BufRead};
+use std::path::PathBuf;
+use std::str::FromStr;
+
+use clap::Parser;
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
+
+use prism_core::address::{self, AddressKind};
+use stellar_strkey::Strkey;
+
+// ─── CLI ────────────────────────────────────────────────────────────────────
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "prism-diff",
+    version,
+    about = "Differential fuzzing of prism-core against the stellar-strkey reference decoder.\n\
+             For each input, runs both decoders and reports any divergence in\n\
+             accept/reject verdicts or decoded fields."
+)]
+struct Cli {
+    /// Generate N random strings and diff each one
+    #[arg(long, value_name = "N", conflicts_with_all = ["corpus", "stdin_mode"])]
+    random: Option<usize>,
+
+    /// Read newline-delimited inputs from FILE
+    #[arg(long, value_name = "FILE", conflicts_with_all = ["random", "stdin_mode"])]
+    corpus: Option<PathBuf>,
+
+    /// Read newline-delimited inputs from stdin
+    #[arg(long = "stdin", conflicts_with_all = ["random", "corpus"])]
+    stdin_mode: bool,
+
+    /// Fix the PRNG seed for reproducible runs
+    #[arg(long, value_name = "U64")]
+    seed: Option<u64>,
+
+    /// Print every comparison, not just divergences
+    #[arg(long, short)]
+    verbose: bool,
+}
+
+// ─── Statistics ─────────────────────────────────────────────────────────────
+
+#[derive(Default)]
+struct Stats {
+    total: usize,
+    agree: usize,
+    divergences: usize,
+    /// Both rejected (valid agreement)
+    both_rejected: usize,
+    /// StarKey accepted a type that prism doesn't handle (T/X/P/L/B), or
+    /// the S-prefix was intentionally rejected by strkey.
+    non_target_skipped: usize,
+}
+
+// ─── Divergence report ──────────────────────────────────────────────────────
+
+struct Divergence {
+    input: String,
+    prism_result: String,
+    strkey_result: String,
+    description: String,
+}
+
+impl Divergence {
+    fn print(&self) {
+        eprintln!("─── DIVERGENCE ───────────────────────────────────────────────");
+        eprintln!("  Input:       {:?}", self.input);
+        eprintln!("  prism-core:  {}", self.prism_result);
+        eprintln!("  strkey:      {}", self.strkey_result);
+        eprintln!("  Description: {}", self.description);
+        eprintln!();
+    }
+}
+
+// ─── Main ───────────────────────────────────────────────────────────────────
+
+fn main() {
+    let cli = Cli::parse();
+
+    if cli.random.is_none() && cli.corpus.is_none() && !cli.stdin_mode {
+        eprintln!("error: specify one of --random <N>, --corpus <FILE>, or --stdin");
+        eprintln!("  e.g.  cargo run --features diff --bin prism-diff -- --random 10000");
+        std::process::exit(2);
+    }
+
+    let seed = cli.seed.unwrap_or_else(|| rand::thread_rng().gen());
+    let mut rng: StdRng = StdRng::seed_from_u64(seed);
+
+    if cli.verbose {
+        eprintln!("PRNG seed: {seed}");
+    }
+
+    let stats = if let Some(n) = cli.random {
+        run_random(&mut rng, n, cli.verbose)
+    } else if let Some(path) = cli.corpus {
+        run_corpus(&path, cli.verbose)
+    } else {
+        run_stdin(cli.verbose)
+    };
+
+    eprintln!();
+    eprintln!("══════════════════════════════════════════════════════════════");
+    eprintln!("  Total inputs:       {}", stats.total);
+    eprintln!(
+        "  Agreed:             {} (incl. {} both-rejected)",
+        stats.agree, stats.both_rejected
+    );
+    eprintln!("  Divergences:        {}", stats.divergences);
+    eprintln!(
+        "  Non-target skipped: {} (T/X/P/L/B keys, or S prefix)",
+        stats.non_target_skipped
+    );
+    eprintln!("══════════════════════════════════════════════════════════════");
+
+    if stats.divergences > 0 {
+        std::process::exit(1);
+    }
+}
+
+// ─── Input sources ──────────────────────────────────────────────────────────
+
+fn run_random(rng: &mut StdRng, n: usize, verbose: bool) -> Stats {
+    let mut stats = Stats::default();
+    for _ in 0..n {
+        diff_one(&random_string(rng), verbose, &mut stats);
+    }
+    stats
+}
+
+fn run_corpus(path: &PathBuf, verbose: bool) -> Stats {
+    let file = std::fs::File::open(path).unwrap_or_else(|e| {
+        eprintln!("error: cannot open corpus file {}: {e}", path.display());
+        std::process::exit(2);
+    });
+    let mut stats = Stats::default();
+    for line in io::BufReader::new(file).lines() {
+        diff_one(&line.unwrap_or_default(), verbose, &mut stats);
+    }
+    stats
+}
+
+fn run_stdin(verbose: bool) -> Stats {
+    let mut stats = Stats::default();
+    for line in io::stdin().lock().lines() {
+        diff_one(&line.unwrap_or_default(), verbose, &mut stats);
+    }
+    stats
+}
+
+// ─── Core comparison logic ──────────────────────────────────────────────────
+
+fn diff_one(input: &str, verbose: bool, stats: &mut Stats) {
+    stats.total += 1;
+
+    let prism = address::parse(input);
+    let strkey = Strkey::from_str(input);
+
+    // Both rejected – agreement.
+    if prism.is_err() && strkey.is_err() {
+        // If strkey rejected because of S-prefix, skip — prism doesn't handle S.
+        if input.starts_with('S') || input.starts_with('s') {
+            stats.non_target_skipped += 1;
+            if verbose {
+                eprintln!("SKIP S-prefix  ← {input:?}");
+            }
+            return;
+        }
+        stats.agree += 1;
+        stats.both_rejected += 1;
+        if verbose {
+            eprintln!("AGREE reject  ← {input:?}");
+        }
+        return;
+    }
+
+    // Build display strings up front.
+    let prism_disp = match &prism {
+        Ok(a) => format!("Ok({:?})", a.kind()),
+        Err(e) => format!("Err({e})"),
+    };
+    let strkey_disp = match &strkey {
+        Ok(sk) => format!("Ok({sk:?})"),
+        Err(e) => format!("Err({e})"),
+    };
+
+    // ── One decoder accepted, the other rejected ────────────────────────
+
+    let prism_ok = prism.is_ok();
+    let strkey_ok = strkey.is_ok();
+
+    if prism_ok != strkey_ok {
+        // If starKey accepted a type that prism-core doesn't handle
+        // (T, X, P, L, B), this is expected — prism only deals with G/M/C.
+        if let Ok(ref sk) = strkey {
+            if is_non_target_strkey(sk) {
+                stats.non_target_skipped += 1;
+                if verbose {
+                    eprintln!("SKIP non-target ← {input:?}");
+                }
+                return;
+            }
+        }
+
+        stats.divergences += 1;
+        let description = if prism_ok {
+            "Accept/reject mismatch: prism-core accepted but stellar-strkey rejected"
+                .to_string()
+        } else {
+            "Accept/reject mismatch: prism-core rejected but stellar-strkey accepted"
+                .to_string()
+        };
+        let div = Divergence {
+            input: input.to_string(),
+            prism_result: prism_disp,
+            strkey_result: strkey_disp,
+            description,
+        };
+        div.print();
+        return;
+    }
+
+    // ── Both accepted – compare decoded fields ─────────────────────────
+
+    let prism_addr = prism.unwrap();
+    let strkey_val = strkey.unwrap();
+
+    let divergence = compare_decoded(&prism_addr, &strkey_val);
+
+    if let Some(desc) = divergence {
+        stats.divergences += 1;
+        let div = Divergence {
+            input: input.to_string(),
+            prism_result: format!("Ok({:?})", prism_addr.kind()),
+            strkey_result: format!("Ok({strkey_val:?})"),
+            description: desc,
+        };
+        div.print();
+    } else {
+        stats.agree += 1;
+        if verbose {
+            eprintln!("AGREE accept  ← {input:?}");
+        }
+    }
+}
+
+/// Compare the decoded fields of a prism-core `Address` and a `stellar-strkey`
+/// `Strkey`. Returns `None` if they agree, or a description string if they
+/// diverge.
+fn compare_decoded(prism: &address::Address, strkey: &Strkey) -> Option<String> {
+    match (prism.kind(), strkey) {
+        // ── G-address ──────────────────────────────────────────────────
+        (AddressKind::G, Strkey::PublicKeyEd25519(_)) => None,
+
+        // ── M-address ──────────────────────────────────────────────────
+        (AddressKind::M, Strkey::MuxedAccountEd25519(ma)) => {
+            let strkey_muxed_id = ma.id;
+            let prism_muxed_id = prism.muxed_id();
+
+            if prism_muxed_id != Some(strkey_muxed_id) {
+                return Some(format!(
+                    "Muxed ID mismatch: prism={prism_muxed_id:?}, strkey={strkey_muxed_id}"
+                ));
+            }
+
+            // Also compare the reconstructed base-G address.
+            if let (Some(prism_base_g), Ok(decoded_base_g)) =
+                (prism.base_g(), address::encode_g_address(&ma.ed25519))
+            {
+                if prism_base_g != decoded_base_g {
+                    return Some(format!(
+                        "Base-G mismatch: prism={prism_base_g:?}, strkey-derived={decoded_base_g:?}"
+                    ));
+                }
+            }
+
+            None
+        }
+
+        // ── C-address ──────────────────────────────────────────────────
+        (AddressKind::C, Strkey::Contract(_)) => None,
+
+        // ── Kind mismatch ──────────────────────────────────────────────
+        (pk, sk) => Some(format!(
+            "Kind mismatch: prism returned {pk:?}, strkey returned {sk:?}"
+        )),
+    }
+}
+
+/// Returns true if the `Strkey` variant is one that prism-core does not handle
+/// (i.e., T, X, P, L, B). prism-core only parses G, M, and C addresses.
+fn is_non_target_strkey(sk: &Strkey) -> bool {
+    matches!(
+        sk,
+        Strkey::PreAuthTx(_)
+            | Strkey::HashX(_)
+            | Strkey::SignedPayloadEd25519(_)
+            | Strkey::LiquidityPool(_)
+            | Strkey::ClaimableBalance(_)
+    )
+}
+
+// ─── Random string generation ───────────────────────────────────────────────
+
+const STRKEY_ALPHABET: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
+
+/// Generate a random string for fuzzing.  80% of the time produce a strkey-
+/// shaped string (starting with G, M, or C with ~correct length); otherwise
+/// produce fully arbitrary printable ASCII.
+fn random_string(rng: &mut StdRng) -> String {
+    if rng.gen_bool(0.80) {
+        // Pick a prefix that prism-core handles.
+        let prefix = match rng.gen_range(0u8..3) {
+            0 => 'G',
+            1 => 'M',
+            _ => 'C',
+        };
+        let target_len: usize = if prefix == 'M' { 69 } else { 56 };
+        let len = target_len.saturating_add_signed(rng.gen_range(-4..=4));
+        let body: String = (0..len.saturating_sub(1))
+            .map(|_| STRKEY_ALPHABET[rng.gen_range(0..STRKEY_ALPHABET.len())] as char)
+            .collect();
+        format!("{prefix}{body}")
+    } else {
+        let len = rng.gen_range(0..=128);
+        (0..len)
+            .map(|_| rng.gen_range(0x20u8..=0x7e) as char)
+            .collect()
+    }
+}

--- a/examples/rust-address-fuzzer/src/main.rs
+++ b/examples/rust-address-fuzzer/src/main.rs
@@ -128,7 +128,7 @@ fn random_string(rng: &mut StdRng) -> String {
             _ => 'C',
         };
         let target_len: usize = if prefix == 'M' { 69 } else { 56 };
-        let len = target_len.saturating_add_signed(rng.gen_range(-4i64..=4));
+        let len = target_len.saturating_add_signed(rng.gen_range(-4..=4));
         let body: String = (0..len.saturating_sub(1))
             .map(|_| STRKEY_ALPHABET[rng.gen_range(0..STRKEY_ALPHABET.len())] as char)
             .collect();

--- a/examples/rust-address-fuzzer/src/parse.rs
+++ b/examples/rust-address-fuzzer/src/parse.rs
@@ -11,8 +11,8 @@ mod tests {
 
     #[test]
     fn parses_valid_g_address() {
-        let result = parse("GAHJJJKMOKYE4RVPZEWZTKH5FVI4PA3VL7GK2LFNUBSGBV3PR5T4Q");
-        assert!(result.is_ok());
+        let result = parse("GAYCUYT553C5LHVE2XPW5GMEJT4BXGM7AHMJWLAPZP53KJO7EIQADRSI");
+        assert!(result.is_ok(), "unexpected error: {result:?}");
         assert_eq!(result.unwrap().kind(), prism_core::address::AddressKind::G);
     }
 


### PR DESCRIPTION
Closes #295

## Summary

This PR adds a `prism-diff` differential testing binary to `prism-core` that compares its address parser against the official [`stellar-strkey`](https://crates.io/crates/stellar-strkey) reference decoder (v0.0.18). It also fixes a real bug discovered by the tool in M-address parsing, fixes pre-existing broken test data, adds a CI workflow for all Rust crates, and fixes a type compatibility issue in the fuzzer.

---

## What changed

### 1. New: `examples/prism-core/src/diff.rs` — differential fuzzing binary
- CLI tool that generates or reads inputs and runs both `prism_core::address::parse()` and `stellar_strkey::Strkey::from_str()` on each input
- Supports `--random <N>`, `--corpus <FILE>`, `--stdin` input modes with `--verbose` and `--seed` flags
- Compares accept/reject verdicts and decoded fields (kind, muxed_id, base_g)
- Reports every divergence as a finding, exiting with code 1
- Gracefully skips non-target strkey types that prism doesn't handle (T, X, P, L, B, S)
- Built behind opt-in feature flag: `cargo run --features diff --bin prism-diff -- --random 10000`

### 2. Bug fix: M-address payload byte order
**The diff tool immediately surfaced a real bug:** prism-core always returned the same wrong `muxed_id` (`3470694755858765214`) regardless of input.

**Root cause:** The code read `payload[1..9]` for the muxed ID and `payload[9..41]` for the ed25519 pubkey, but SEP-0023 XDR for `MuxedAccount` specifies **pubkey(32) || id(8)**, not the reverse.

**Fix:** Swapped to read `payload[1..33]` for pubkey and `payload[33..41]` for the muxed ID — matching `stellar-strkey`'s `MuxedAccount::from_payload`.

### 3. Exposed `encode_g_address` as public
Changed from `fn` → `pub fn` so the diff tool can reconstruct base-G addresses from raw pubkey bytes to cross-validate M-address decoding.

### 4. Fixed pre-existing broken test data
- **`valid_g_address_parses`**: was using an invalid strkey. Replaced with verified-valid address from spec vectors.
- **`invalid_base32_character`**: test string was too short (53 chars, G requires 56), hitting `InvalidLength` before `InvalidBase32`. Padded to correct length.

### 5. Fixed `gen_range` type error in fuzzer
Rust 1.97+ requires `gen_range` on `isize` ranges to use unqualified integer literals.

### 6. New CI workflow: `.github/workflows/ci-rust.yml`
- Triggers on PR changes to Rust crates or spec vectors
- Runs `cargo test` for both crates
- Builds `prism-diff` binary
- Smoke tests with 1,000 random inputs (must exit 0)

---

## Verification

```bash
# All 10 unit tests pass
cargo test -p prism-core           # ✅ 7/7
cargo test -p rust-address-fuzzer  # ✅ 3/3

# 0 divergences on spec M-address vectors + valid G-address
printf 'MAYCUYT553C5LHVE2XPW5GMEJT4BXGM7AHMJWLAPZP53KJO7EIQACAAAAAAAAAAAAD672
MAYCUYT553C5LHVE2XPW5GMEJT4BXGM7AHMJWLAPZP53KJO7EIQACAAAAAAAAAAAAHOO2
MAYCUYT553C5LHVE2XPW5GMEJT4BXGM7AHMJWLAPZP53KJO7EIQACABAAAAAAAAAAAFZG
MAYCUYT553C5LHVE2XPW5GMEJT4BXGM7AHMJWLAPZP53KJO7EIQACABAAAAAAAAAAEVIG
MAYCUYT553C5LHVE2XPW5GMEJT4BXGM7AHMJWLAPZP53KJO7EIQAD7777777777774OFW
GAYCUYT553C5LHVE2XPW5GMEJT4BXGM7AHMJWLAPZP53KJO7EIQADRSI' | \
  cargo run --features diff --bin prism-diff -- --stdin --verbose
# ✅ 6/6 agreed, 0 divergences

# 0 divergences on 10,000 random inputs
cargo run --features diff --bin prism-diff -- --random 10000 --seed 12345
# ✅ 10,000 inputs, 0 divergences, 43 non-target skipped
```

---

## Files changed

| File | Change |
|---|---|
| `examples/prism-core/Cargo.toml` | Added `[[bin]]`, `diff` feature, optional deps, `rust-version` |
| `examples/prism-core/src/diff.rs` | **New** — differential fuzzing binary |
| `examples/prism-core/src/address.rs` | Fixed M-address payload order bug, made `encode_g_address` public, fixed test data |
| `examples/rust-address-fuzzer/src/main.rs` | Fixed `gen_range` type for newer Rust |
| `examples/rust-address-fuzzer/src/parse.rs` | Fixed test to use valid G-address |
| `.github/workflows/ci-rust.yml` | **New** — CI workflow for Rust crates |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a command-line tool for comparing address parsing results and detecting discrepancies across implementations.
  * Added support for random, corpus-based, and standard-input testing with summary reporting.

* **Bug Fixes**
  * Improved decoding of muxed addresses to correctly extract base addresses and IDs.
  * Updated address validation coverage with verified valid and invalid examples.

* **Tests**
  * Added automated Rust CI checks, including parser tests, builds, and deterministic smoke testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->