### PR TITLE
feat(rust-fuzzer): implement truncate and pad length mutators + fix broken test data

### DIFF
--- a/examples/prism-core/src/address.rs
+++ b/examples/prism-core/src/address.rs
@@ -195,15 +195,16 @@ mod tests {
 
     #[test]
     fn invalid_base32_character() {
+        // 56-char address with invalid base32 char '1' (0 and 1 are not valid base32)
         assert!(matches!(
-            parse("G0HJJJKMOKYE4RVPZEWZTKH5FVI4PA3VL7GK2LFNUBSGBV3PR5T4Q"),
+            parse("GA1CUYT553C5LHVE2XPW5GMEJT4BXGM7AHMJWLAPZP53KJO7EIQADRSI"),
             Err(ParseError::InvalidBase32 { .. })
         ));
     }
 
     #[test]
     fn valid_g_address_parses() {
-        let result = parse("GAHJJJKMOKYE4RVPZEWZTKH5FVI4PA3VL7GK2LFNUBSGBV3PR5T4Q");
+        let result = parse("GAYCUYT553C5LHVE2XPW5GMEJT4BXGM7AHMJWLAPZP53KJO7EIQADRSI");
         assert!(result.is_ok());
         let parsed = result.unwrap();
         assert_eq!(parsed.kind(), AddressKind::G);
@@ -213,8 +214,8 @@ mod tests {
 
     #[test]
     fn lowercase_normalised_correctly() {
-        let r_lower = parse("gahjjjkmokye4rvpzewztkh5fvi4pa3vl7gk2lfnubsgbv3pr5t4q");
-        let r_upper = parse("GAHJJJKMOKYE4RVPZEWZTKH5FVI4PA3VL7GK2LFNUBSGBV3PR5T4Q");
+        let r_lower = parse("gaycuyt553c5lhve2xpw5gmejt4bxgm7ahmjwlapzp53kjo7eiqadrsi");
+        let r_upper = parse("GAYCUYT553C5LHVE2XPW5GMEJT4BXGM7AHMJWLAPZP53KJO7EIQADRSI");
         assert_eq!(r_lower.is_ok(), r_upper.is_ok());
     }
 

--- a/examples/rust-address-fuzzer/src/main.rs
+++ b/examples/rust-address-fuzzer/src/main.rs
@@ -1,3 +1,4 @@
+mod mutators;
 mod parse;
 
 use std::io::{self, BufRead};
@@ -128,7 +129,7 @@ fn random_string(rng: &mut StdRng) -> String {
             _ => 'C',
         };
         let target_len: usize = if prefix == 'M' { 69 } else { 56 };
-        let len = target_len.saturating_add_signed(rng.gen_range(-4i64..=4));
+        let len = target_len.saturating_add_signed(rng.gen_range(-4isize..=4));
         let body: String = (0..len.saturating_sub(1))
             .map(|_| STRKEY_ALPHABET[rng.gen_range(0..STRKEY_ALPHABET.len())] as char)
             .collect();

--- a/examples/rust-address-fuzzer/src/mutators/length.rs
+++ b/examples/rust-address-fuzzer/src/mutators/length.rs
@@ -1,0 +1,215 @@
+use rand::Rng;
+
+/// Base32 alphabet used by StrKey (RFC 4648 without padding).
+const STRKEY_ALPHABET: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
+
+/// Truncates a random number of trailing characters from `addr`.
+///
+/// At least 1 character (and no more than half the address length) is removed.
+/// The resulting string is guaranteed to have a different length than the
+/// original, so the parser must reject it.
+pub fn truncate(addr: &str, rng: &mut impl Rng) -> String {
+    let len = addr.len();
+    // Remove between 1 and max(1, len/2) trailing chars
+    let max_remove = (len / 2).max(1);
+    let remove = rng.gen_range(1..=max_remove);
+    let truncated_len = len.saturating_sub(remove);
+    addr[..truncated_len].to_string()
+}
+
+/// Appends random base32 characters to `addr`.
+///
+/// Between 1 and 16 extra characters are added, guaranteeing the result is
+/// too long for any valid Stellar address.
+pub fn pad(addr: &str, rng: &mut impl Rng) -> String {
+    let extra = rng.gen_range(1..=16);
+    let suffix: String = (0..extra)
+        .map(|_| STRKEY_ALPHABET[rng.gen_range(0..STRKEY_ALPHABET.len())] as char)
+        .collect();
+    format!("{addr}{suffix}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::rngs::StdRng;
+    use rand::SeedableRng;
+
+    // Valid addresses from the spec test vectors.
+    const VALID_G: &str = "GAYCUYT553C5LHVE2XPW5GMEJT4BXGM7AHMJWLAPZP53KJO7EIQADRSI";
+    const VALID_M: &str = "MAYCUYT553C5LHVE2XPW5GMEJT4BXGM7AHMJWLAPZP53KJO7EIQACAAAAAAAAAAAAD672";
+
+    // ------------------------------------------------------------------
+    // setup guard: verify base addresses are parseable first
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn base_addresses_are_valid() {
+        assert!(
+            prism_core::address::parse(VALID_G).is_ok(),
+            "VALID_G must be parseable: {VALID_G}"
+        );
+        assert!(
+            prism_core::address::parse(VALID_M).is_ok(),
+            "VALID_M must be parseable: {VALID_M}"
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // truncate sanity checks
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn truncate_produces_shorter_string() {
+        let mut rng = StdRng::seed_from_u64(42);
+        let result = truncate(VALID_G, &mut rng);
+        assert!(
+            result.len() < VALID_G.len(),
+            "truncated string must be shorter ({} vs {})",
+            result.len(),
+            VALID_G.len()
+        );
+    }
+
+    #[test]
+    fn truncate_preserves_prefix() {
+        let mut rng = StdRng::seed_from_u64(42);
+        let result = truncate(VALID_G, &mut rng);
+        assert_eq!(&result[..1], "G", "prefix must be preserved");
+    }
+
+    // ------------------------------------------------------------------
+    // truncate: every seed must produce Err (no panic, no Ok)
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn truncate_g_always_err_no_panic() {
+        for seed in 0..200 {
+            let mut rng = StdRng::seed_from_u64(seed);
+            let result = truncate(VALID_G, &mut rng);
+            let parse_out = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                prism_core::address::parse(&result)
+            }));
+            match parse_out {
+                Ok(Err(_)) => {} // expected
+                Ok(Ok(addr)) => {
+                    panic!(
+                        "truncated G input {result:?} (len={}, seed={seed}) parsed as OK({addr:?})",
+                        result.len()
+                    )
+                }
+                Err(_) => {
+                    panic!(
+                        "truncated G input {result:?} (len={}, seed={seed}) caused a panic",
+                        result.len()
+                    )
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn truncate_m_always_err_no_panic() {
+        for seed in 0..200 {
+            let mut rng = StdRng::seed_from_u64(seed);
+            let result = truncate(VALID_M, &mut rng);
+            let parse_out = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                prism_core::address::parse(&result)
+            }));
+            match parse_out {
+                Ok(Err(_)) => {} // expected
+                Ok(Ok(addr)) => {
+                    panic!(
+                        "truncated M input {result:?} (len={}, seed={seed}) parsed as OK({addr:?})",
+                        result.len()
+                    )
+                }
+                Err(_) => {
+                    panic!(
+                        "truncated M input {result:?} (len={}, seed={seed}) caused a panic",
+                        result.len()
+                    )
+                }
+            }
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // pad sanity checks
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn pad_produces_longer_string() {
+        let mut rng = StdRng::seed_from_u64(42);
+        let result = pad(VALID_G, &mut rng);
+        assert!(
+            result.len() > VALID_G.len(),
+            "padded string must be longer ({} vs {})",
+            result.len(),
+            VALID_G.len()
+        );
+    }
+
+    #[test]
+    fn pad_preserves_prefix() {
+        let mut rng = StdRng::seed_from_u64(42);
+        let result = pad(VALID_G, &mut rng);
+        assert_eq!(&result[..1], "G", "prefix must be preserved");
+    }
+
+    // ------------------------------------------------------------------
+    // pad: every seed must produce Err (no panic, no Ok)
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn pad_g_always_err_no_panic() {
+        for seed in 0..200 {
+            let mut rng = StdRng::seed_from_u64(seed);
+            let result = pad(VALID_G, &mut rng);
+            let parse_out = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                prism_core::address::parse(&result)
+            }));
+            match parse_out {
+                Ok(Err(_)) => {} // expected
+                Ok(Ok(addr)) => {
+                    panic!(
+                        "padded G input {result:?} (len={}, seed={seed}) parsed as OK({addr:?})",
+                        result.len()
+                    )
+                }
+                Err(_) => {
+                    panic!(
+                        "padded G input {result:?} (len={}, seed={seed}) caused a panic",
+                        result.len()
+                    )
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn pad_m_always_err_no_panic() {
+        for seed in 0..200 {
+            let mut rng = StdRng::seed_from_u64(seed);
+            let result = pad(VALID_M, &mut rng);
+            let parse_out = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                prism_core::address::parse(&result)
+            }));
+            match parse_out {
+                Ok(Err(_)) => {} // expected
+                Ok(Ok(addr)) => {
+                    panic!(
+                        "padded M input {result:?} (len={}, seed={seed}) parsed as OK({addr:?})",
+                        result.len()
+                    )
+                }
+                Err(_) => {
+                    panic!(
+                        "padded M input {result:?} (len={}, seed={seed}) caused a panic",
+                        result.len()
+                    )
+                }
+            }
+        }
+    }
+}

--- a/examples/rust-address-fuzzer/src/mutators/mod.rs
+++ b/examples/rust-address-fuzzer/src/mutators/mod.rs
@@ -1,0 +1,3 @@
+// Functions are exported for external use; unused in this binary crate.
+#![allow(dead_code)]
+pub mod length;

--- a/examples/rust-address-fuzzer/src/parse.rs
+++ b/examples/rust-address-fuzzer/src/parse.rs
@@ -11,7 +11,7 @@ mod tests {
 
     #[test]
     fn parses_valid_g_address() {
-        let result = parse("GAHJJJKMOKYE4RVPZEWZTKH5FVI4PA3VL7GK2LFNUBSGBV3PR5T4Q");
+        let result = parse("GAYCUYT553C5LHVE2XPW5GMEJT4BXGM7AHMJWLAPZP53KJO7EIQADRSI");
         assert!(result.is_ok());
         assert_eq!(result.unwrap().kind(), prism_core::address::AddressKind::G);
     }


### PR DESCRIPTION
## Summary

Implements length-mutation fuzzer helpers (`truncate` / `pad`) for the
rust-address-fuzzer and fixes pre-existing broken test data in both
Rust crates. Closes #291.

## Problem

Off-by-one and truncated inputs are classic parser killers. Feeding
progressively shorter and padded strings probes the length-handling
logic that base32 decoders often get wrong. The rust-address-fuzzer
had no dedicated mutators for length manipulation, leaving the
parser's edge-case behaviour around over-length and under-length
inputs unexplored.

Additionally, several tests across both Rust crates used a phantom
G address (`GAHJJJKMOKYE4RVPZEWZTKH5FVI4PA3VL7GK2LFNUBSGBV3PR5T4Q`)
that was only **53 characters** long, while the parser declares
`LEN_G = 56`. These tests silently failed to validate anything
useful because the parse step always rejected the input before
reaching the logic being tested.

## Changes

### New: length mutators (`src/mutators/length.rs`)

**`truncate(addr, rng)`** — Randomly removes 1 to `max(1, len/2)`
trailing characters. Uses `saturating_sub` to guard against underflow
on empty / 1-char inputs. The shortened string is always too short
for any valid Stellar address.

**`pad(addr, rng)`** — Appends 1–16 random RFC 4648 base32 characters
(A–Z, 2–7). The extended string is always too long for any valid
Stellar address.

Module wiring in `src/mutators/mod.rs` with `#![allow(dead_code)]`.

### Bugfixes in existing test data

| File | Test | Fix |
|------|------|-----|
| `prism-core/src/address.rs` | `valid_g_address_parses` | 53-char phantom → 56-char spec-vector address |
| `prism-core/src/address.rs` | `lowercase_normalised_correctly` | Same replacement for both lower/upper variants |
| `prism-core/src/address.rs` | `invalid_base32_character` | Too-short address that failed at length gate → 56-char address with invalid char `1` that reaches the base32 check |
| `rust-address-fuzzer/src/parse.rs` | `parses_valid_g_address` | 53-char phantom → 56-char spec-vector address |
| `rust-address-fuzzer/src/main.rs` | (compilation) | `saturating_add_signed` expects `isize`, changed from `i64` range to `isize` |

All fixes use the valid G address `GAYCUYT553C5LHVE2XPW5GMEJT4BXGM7AHMJWLAPZP53KJO7EIQADRSI`
from the normative `spec/vectors.json` (module `muxed_encode`).

## Test coverage

### 12 rust-address-fuzzer tests — all pass

| Test | Description |
|------|-------------|
| `base_addresses_are_valid` | Setup guard: `VALID_G` and `VALID_M` from spec vectors are parseable |
| `truncate_produces_shorter_string` | Truncated G address is strictly shorter |
| `truncate_preserves_prefix` | Prefix character preserved after truncation |
| `truncate_g_always_err_no_panic` | 200 seeds on G address → always Err, never Ok, never panics |
| `truncate_m_always_err_no_panic` | 200 seeds on M address → always Err, never Ok, never panics |
| `pad_produces_longer_string` | Padded G address is strictly longer |
| `pad_preserves_prefix` | Prefix character preserved after padding |
| `pad_g_always_err_no_panic` | 200 seeds on G address → always Err, never Ok, never panics |
| `pad_m_always_err_no_panic` | 200 seeds on M address → always Err, never Ok, never panics |
| `parses_valid_g_address` | (fixed) Valid spec-vector address parses correctly |
| `rejects_garbage` | Random string rejected |
| `rejects_empty_string` | Empty input rejected |

Each parse call in the four "always Err" tests is wrapped in
`std::panic::catch_unwind` to catch both partial-parse `Ok` results
and genuine panics. 200 seeds × 4 test cases = **800 distinct
parse attempts**, all producing errors with zero panics.

### 7 prism-core tests — all pass

All original tests now pass with the corrected addresses.

## CI validation

| Check | Result |
|-------|--------|
| `cargo test` (rust-address-fuzzer) | 12 passed, 0 failed |
| `cargo test` (prism-core) | 7 passed, 0 failed |
| `cargo clippy --all-targets` (rust-address-fuzzer) | No warnings |
| `cargo clippy --all-targets` (prism-core) | No warnings |

## Design decisions

- **truncation range (1 to len/2)**: Removing more than half leaves
  strings rejected at the prefix check; keeping the range ensures
  the parser consistently reaches length-validation logic.
- **pad range (1–16)**: Stellar addresses have fixed lengths (56/69).
  Even +1 guarantees InvalidLength. The 1–16 range adds variety.
- **Seed-based determinism**: `StdRng::seed_from_u64` makes every
  test run reproducible for debugging.
- **Spec-vector addresses**: Cross-language consistency — the same
  addresses pass TypeScript, Go, Dart, and now Rust.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated address validation test cases with refreshed lowercase and uppercase examples.
  * Expanded malformed-address coverage by testing truncated and overlong addresses.
  * Confirmed invalid address inputs are rejected safely without causing application crashes.
  * Added deterministic checks to improve confidence in address parsing across varied malformed inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->